### PR TITLE
Add heart rate only task

### DIFF
--- a/CardiorespiratoryFitness/CRFTestApp/TaskTableViewController.swift
+++ b/CardiorespiratoryFitness/CRFTestApp/TaskTableViewController.swift
@@ -40,7 +40,7 @@ class TaskTableViewController: UITableViewController {
 
     @IBOutlet weak var detailLabel: UILabel!
     
-    var tasks = CRFTaskIdentifier.all().map { CRFTaskInfo($0) }
+    var tasks = CRFTaskIdentifier.allCases.map { CRFTaskInfo($0) }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F80D320321546A0B00E881CB /* HeartRate_Only.json in Resources */ = {isa = PBXBuildFile; fileRef = F80D31F921546A0B00E881CB /* HeartRate_Only.json */; };
 		F82AE7F52064274A00952D74 /* UIColor+CRFDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82AE7F42064274A00952D74 /* UIColor+CRFDefaults.swift */; };
 		F880C1202051F1E200ACB4D4 /* CRFFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F880C11F2051F1E200ACB4D4 /* CRFFactory.swift */; };
 		F880C12F2051F2A700ACB4D4 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F880C12E2051F2A700ACB4D4 /* Images.xcassets */; };
@@ -182,6 +183,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F80D31F921546A0B00E881CB /* HeartRate_Only.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = HeartRate_Only.json; sourceTree = "<group>"; };
 		F82AE7F42064274A00952D74 /* UIColor+CRFDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+CRFDefaults.swift"; sourceTree = "<group>"; };
 		F880C11F2051F1E200ACB4D4 /* CRFFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFFactory.swift; sourceTree = "<group>"; };
 		F880C12E2051F2A700ACB4D4 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
@@ -343,6 +345,7 @@
 				F880C16E2051FCD400ACB4D4 /* ActiveTaskSteps.storyboard */,
 				F880C16D2051FCD400ACB4D4 /* Cardio_12MT.json */,
 				F880C16A2051FCD400ACB4D4 /* Cardio_Stair_Step.json */,
+				F80D31F921546A0B00E881CB /* HeartRate_Only.json */,
 				F880C16C2051FCD400ACB4D4 /* HeartrateStep.json */,
 				F880C1702051FCD400ACB4D4 /* Cardio_12MT.html */,
 				F880C16F2051FCD400ACB4D4 /* Stair_Step.html */,
@@ -714,6 +717,7 @@
 				F880C1772051FCD400ACB4D4 /* Cardio_12MT.html in Resources */,
 				F880C1732051FCD400ACB4D4 /* HeartrateStep.json in Resources */,
 				F880C1762051FCD400ACB4D4 /* Stair_Step.html in Resources */,
+				F80D320321546A0B00E881CB /* HeartRate_Only.json in Resources */,
 				F880C1742051FCD400ACB4D4 /* Cardio_12MT.json in Resources */,
 				F880C1312051F49400ACB4D4 /* Colors.xcassets in Resources */,
 				F880C1752051FCD400ACB4D4 /* ActiveTaskSteps.storyboard in Resources */,

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFFactory.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFFactory.swift
@@ -37,6 +37,12 @@ extension RSDStepType {
     static let heartRate: RSDStepType = "heartRate"
 }
 
+extension RSDStepNavigatorType {
+    
+    /// Defaults to transforming a navigator from a section.
+    public static let transform: RSDStepNavigatorType = "transform"
+}
+
 open class CRFFactory: RSDFactory {
 
     /// Override the base factory to vend the heart rate step.
@@ -46,6 +52,17 @@ open class CRFFactory: RSDFactory {
             return try CRFHeartRateStep(from: decoder)
         default:
             return try super.decodeStep(from: decoder, with: type)
+        }
+    }
+    
+    /// Override to implement custom step navigators.
+    override open func decodeStepNavigator(from decoder: Decoder, with type: RSDStepNavigatorType) throws -> RSDStepNavigator {
+        switch type {
+        case .transform:
+            let sectionStep = try self.decodeTransformableStep(from: decoder) as! RSDSectionStep
+            return sectionStep
+        default:
+            return try super.decodeStepNavigator(from: decoder, with: type)
         }
     }
 }

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFTaskInfo.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFTaskInfo.swift
@@ -37,10 +37,10 @@ import Foundation
 public enum CRFTaskIdentifier : String, Codable, CaseIterable {
     
     /// The Cardio 12-minute Distance Test.
-    case cardio12MT = "Cardio 12MT"
+    case cardio12MT = "Cardio12MT"
     
     /// The Cardio Stair Step Test.
-    case cardioStairStep = "Cardio Stair Step"
+    case cardioStairStep = "CardioStairStep"
     
     /// The heart rate measurement only.
     case heartRateOnly = "HeartRate"

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Cardio_12MT.json
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Cardio_12MT.json
@@ -1,5 +1,5 @@
 {
-    "identifier"        : "Cardio 12MT",
+    "identifier"        : "Cardio12MT",
     "actions"           : { "cancel": { "type": "default", "iconName": "closeActivity" }},
     "shouldHideActions" : ["goBackward", "skip"],
     "progressMarkers"   : ["volumeUp", "goOutside", "heartRate.before", "run", "heartRate.after", "surveyAfter"],

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Cardio_Stair_Step.json
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Cardio_Stair_Step.json
@@ -1,5 +1,5 @@
 {
-    "identifier"        : "Cardio Stair Step",
+    "identifier"        : "CardioStairStep",
     "actions"           : { "cancel": { "type":"default", "iconName": "closeActivity"}},
     "shouldHideActions" : ["goBackward", "skip"],
     "progressMarkers"   : ["volumeUp", "heartRate.before", "stairStep", "heartRate.after"],

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/HeartRate_Only.json
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/HeartRate_Only.json
@@ -1,0 +1,22 @@
+{
+    "identifier"        : "HeartRate",
+    "actions"           : { "cancel": { "type":"default", "iconName": "closeActivity"}},
+    "shouldHideActions" : ["goBackward", "skip"],
+    "asyncActions"      : [
+        {
+            "identifier"              : "motion",
+            "type"                    : "motion",
+            "startStepIdentifier"     : "heartRate",
+            "StopStepIdentifier"      : "heartRate",
+            "requiresBackgroundAudio" : true,
+            "recorderTypes"           : ["accelerometer", "gyro"]
+        }
+    ],
+    "type" : "transform",
+    "steps" : [{
+        "identifier" : "heartRate",
+        "isResting" : true,
+        "shouldSaveBuffer" : true
+    }],
+    "resourceTransformer" : { "resourceName": "HeartrateStep.json"}
+}

--- a/CardiorespiratoryFitness/CardiorespiratoryFitnessTests/ModelTests.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitnessTests/ModelTests.swift
@@ -51,7 +51,7 @@ class ModelTests: XCTestCase {
         
         let taskInfo = CRFTaskInfo(.cardio12MT)
         
-        XCTAssertEqual(taskInfo.identifier, "Cardio 12MT")
+        XCTAssertEqual(taskInfo.identifier, "Cardio12MT")
         XCTAssertEqual(taskInfo.title, "12 Minute Distance Test")
         XCTAssertEqual(taskInfo.subtitle, "15 minutes")
         XCTAssertNil(taskInfo.detail)
@@ -63,7 +63,7 @@ class ModelTests: XCTestCase {
 
         let taskInfo = CRFTaskInfo(.cardioStairStep)
         
-        XCTAssertEqual(taskInfo.identifier, "Cardio Stair Step")
+        XCTAssertEqual(taskInfo.identifier, "CardioStairStep")
         XCTAssertEqual(taskInfo.title, "3 Minute Stair Test")
         XCTAssertEqual(taskInfo.subtitle, "5 minutes")
         XCTAssertNil(taskInfo.detail)
@@ -72,10 +72,10 @@ class ModelTests: XCTestCase {
     
     func testDecodeTasks() {
         // Check that the JSON is decoding properly.
-        for taskIdentifier in CRFTaskIdentifier.all() {
+        for taskIdentifier in CRFTaskIdentifier.allCases {
             let factory = CRFFactory()
             do {
-                let taskTransformer = taskIdentifier.resourceTransformer()
+                let taskTransformer = CRFTaskTransformer(taskIdentifier)
                 let _ = try factory.decodeTask(with: taskTransformer)
             } catch let err {
                 XCTFail("Failed to decode \(taskIdentifier): \(err)")


### PR DESCRIPTION
Note: The heart rate only task is currently set up to capture raw video feed and motion sensor data, which are *not* included by default for stair step and 12MT.

This sets up for the CRF validation part 2. Also, this can be used as-is by third-party developers interested in capturing video and motion sensor data.