### PR TITLE
Add validation apps

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
-[submodule "SageResearch"]
-	path = SageResearch
-	url = https://github.com/Sage-Bionetworks/SageResearch.git
+[submodule "BridgeApp"]
+	path = BridgeApp
+	url = https://github.com/Sage-Bionetworks/BridgeApp-Apple-SDK.git

--- a/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
+++ b/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
@@ -1,0 +1,601 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 50;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		F8258597215DADA7007E7965 /* ParticipantIDStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */; };
+		F8F366B42155D5DE00A49F89 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B32155D5DE00A49F89 /* AppDelegate.swift */; };
+		F8F366B62155D5DE00A49F89 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B52155D5DE00A49F89 /* MainViewController.swift */; };
+		F8F366B92155D5DE00A49F89 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8F366B72155D5DE00A49F89 /* Main.storyboard */; };
+		F8F366BE2155D5DF00A49F89 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8F366BC2155D5DF00A49F89 /* LaunchScreen.storyboard */; };
+		F8F366E92155D65400A49F89 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8F366E82155D65400A49F89 /* Assets.xcassets */; };
+		F8F366F12155D6A600A49F89 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366D22155D5F400A49F89 /* BridgeApp.framework */; };
+		F8F366F22155D6A600A49F89 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366D22155D5F400A49F89 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8F367002155D7A000A49F89 /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */; };
+		F8F367012155D7A000A49F89 /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8F367072155DA4000A49F89 /* BridgeInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8F367062155DA4000A49F89 /* BridgeInfo.plist */; };
+		F8F367092155DA8C00A49F89 /* crf-module.pem in Resources */ = {isa = PBXBuildFile; fileRef = F8F367082155DA8C00A49F89 /* crf-module.pem */; };
+		F8F3670B2155DA9C00A49F89 /* BridgeInfo-private.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8F3670A2155DA9C00A49F89 /* BridgeInfo-private.plist */; };
+		F8F367242155DE8D00A49F89 /* ExternalIDRegistrationViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F367232155DE8D00A49F89 /* ExternalIDRegistrationViewController.swift */; };
+		F8F3678C21597DF100A49F89 /* HeartRate_Measurement.json in Resources */ = {isa = PBXBuildFile; fileRef = F8F3678B21597DF100A49F89 /* HeartRate_Measurement.json */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F8F366D12155D5F400A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F83B44A52032467D002825AE;
+			remoteInfo = "BridgeApp (iOS)";
+		};
+		F8F366D32155D5F400A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F83B44AE2032467D002825AE;
+			remoteInfo = BridgeAppTests;
+		};
+		F8F366D52155D5F400A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F83B450220324A33002825AE;
+			remoteInfo = BridgeAppExample;
+		};
+		F8F366E02155D60200A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F88725D92051C0F800A4B82F;
+			remoteInfo = CardiorespiratoryFitness;
+		};
+		F8F366E22155D60200A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F88725E22051C0F900A4B82F;
+			remoteInfo = CardiorespiratoryFitnessTests;
+		};
+		F8F366E42155D60200A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F8BA7FE02051DC2D00A5B83A;
+			remoteInfo = CRFTestApp;
+		};
+		F8F366E62155D60200A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F8BA7FF32051DC2E00A5B83A;
+			remoteInfo = CRFTestAppUITests;
+		};
+		F8F366F32155D6A600A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F83B44A42032467D002825AE;
+			remoteInfo = "BridgeApp (iOS)";
+		};
+		F8F367022155D7A000A49F89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F88725D82051C0F800A4B82F;
+			remoteInfo = CardiorespiratoryFitness;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F8F366ED2155D69400A49F89 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				F8F367012155D7A000A49F89 /* CardiorespiratoryFitness.framework in Embed Frameworks */,
+				F8F366F22155D6A600A49F89 /* BridgeApp.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantIDStepViewController.swift; sourceTree = "<group>"; };
+		F8F366B02155D5DE00A49F89 /* CRFHeartRate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CRFHeartRate.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8F366B32155D5DE00A49F89 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		F8F366B52155D5DE00A49F89 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
+		F8F366B82155D5DE00A49F89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		F8F366BD2155D5DF00A49F89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		F8F366BF2155D5DF00A49F89 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeApp.xcodeproj; path = ../BridgeApp/BridgeApp/BridgeApp.xcodeproj; sourceTree = "<group>"; };
+		F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CardiorespiratoryFitness.xcodeproj; path = ../CardiorespiratoryFitness/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj; sourceTree = "<group>"; };
+		F8F366E82155D65400A49F89 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = "../../../CardiorespiratoryFitness-iOS/CardiorespiratoryFitness/CRFTestApp/Assets.xcassets"; sourceTree = "<group>"; };
+		F8F367042155D7B500A49F89 /* CRFHeartRate.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CRFHeartRate.entitlements; sourceTree = "<group>"; };
+		F8F367062155DA4000A49F89 /* BridgeInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BridgeInfo.plist; sourceTree = "<group>"; };
+		F8F367082155DA8C00A49F89 /* crf-module.pem */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = "crf-module.pem"; path = "../../../iOSPrivateProjectInfo/CRFModuleValidation/crf-module.pem"; sourceTree = "<group>"; };
+		F8F3670A2155DA9C00A49F89 /* BridgeInfo-private.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "BridgeInfo-private.plist"; path = "../../../iOSPrivateProjectInfo/CRFModuleValidation/BridgeInfo-private.plist"; sourceTree = "<group>"; };
+		F8F367232155DE8D00A49F89 /* ExternalIDRegistrationViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ExternalIDRegistrationViewController.swift; sourceTree = "<group>"; };
+		F8F3678B21597DF100A49F89 /* HeartRate_Measurement.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = HeartRate_Measurement.json; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		F8F366AD2155D5DE00A49F89 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8F367002155D7A000A49F89 /* CardiorespiratoryFitness.framework in Frameworks */,
+				F8F366F12155D6A600A49F89 /* BridgeApp.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		F8258590215DACAB007E7965 /* Heart Rate */ = {
+			isa = PBXGroup;
+			children = (
+				F8F3678B21597DF100A49F89 /* HeartRate_Measurement.json */,
+				F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */,
+			);
+			name = "Heart Rate";
+			sourceTree = "<group>";
+		};
+		F8F366A72155D5DE00A49F89 = {
+			isa = PBXGroup;
+			children = (
+				F8F366B22155D5DE00A49F89 /* CRFHeartRate */,
+				F8F366B12155D5DE00A49F89 /* Products */,
+				F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */,
+				F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */,
+			);
+			sourceTree = "<group>";
+		};
+		F8F366B12155D5DE00A49F89 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8F366B02155D5DE00A49F89 /* CRFHeartRate.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F8F366B22155D5DE00A49F89 /* CRFHeartRate */ = {
+			isa = PBXGroup;
+			children = (
+				F8F366B32155D5DE00A49F89 /* AppDelegate.swift */,
+				F8F366B52155D5DE00A49F89 /* MainViewController.swift */,
+				F8F366B72155D5DE00A49F89 /* Main.storyboard */,
+				F8F366E82155D65400A49F89 /* Assets.xcassets */,
+				F8F366BC2155D5DF00A49F89 /* LaunchScreen.storyboard */,
+				F8258590215DACAB007E7965 /* Heart Rate */,
+				F8F367162155DD1200A49F89 /* Sign in */,
+				F8F367052155D9B800A49F89 /* Support Files */,
+			);
+			path = CRFHeartRate;
+			sourceTree = "<group>";
+		};
+		F8F366C62155D5F300A49F89 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8F366D22155D5F400A49F89 /* BridgeApp.framework */,
+				F8F366D42155D5F400A49F89 /* BridgeAppTests.xctest */,
+				F8F366D62155D5F400A49F89 /* BridgeAppExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F8F366D82155D60200A49F89 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */,
+				F8F366E32155D60200A49F89 /* CardiorespiratoryFitnessTests.xctest */,
+				F8F366E52155D60200A49F89 /* CRFTestApp.app */,
+				F8F366E72155D60200A49F89 /* CRFTestAppUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F8F367052155D9B800A49F89 /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				F8F366BF2155D5DF00A49F89 /* Info.plist */,
+				F8F367062155DA4000A49F89 /* BridgeInfo.plist */,
+				F8F3670A2155DA9C00A49F89 /* BridgeInfo-private.plist */,
+				F8F367082155DA8C00A49F89 /* crf-module.pem */,
+				F8F367042155D7B500A49F89 /* CRFHeartRate.entitlements */,
+			);
+			name = "Support Files";
+			sourceTree = "<group>";
+		};
+		F8F367162155DD1200A49F89 /* Sign in */ = {
+			isa = PBXGroup;
+			children = (
+				F8F367232155DE8D00A49F89 /* ExternalIDRegistrationViewController.swift */,
+			);
+			name = "Sign in";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		F8F366AF2155D5DE00A49F89 /* CRFHeartRate */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F8F366C22155D5DF00A49F89 /* Build configuration list for PBXNativeTarget "CRFHeartRate" */;
+			buildPhases = (
+				F8F366AC2155D5DE00A49F89 /* Sources */,
+				F8F366AD2155D5DE00A49F89 /* Frameworks */,
+				F8F366AE2155D5DE00A49F89 /* Resources */,
+				F8F366ED2155D69400A49F89 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F8F366F42155D6A600A49F89 /* PBXTargetDependency */,
+				F8F367032155D7A000A49F89 /* PBXTargetDependency */,
+			);
+			name = CRFHeartRate;
+			productName = CRFHeartRate;
+			productReference = F8F366B02155D5DE00A49F89 /* CRFHeartRate.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		F8F366A82155D5DE00A49F89 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastSwiftUpdateCheck = 1000;
+				LastUpgradeCheck = 1000;
+				ORGANIZATIONNAME = "Sage Bionetworks";
+				TargetAttributes = {
+					F8F366AF2155D5DE00A49F89 = {
+						CreatedOnToolsVersion = 10.0;
+						SystemCapabilities = {
+							com.apple.ApplicationGroups.iOS = {
+								enabled = 1;
+							};
+							com.apple.BackgroundModes = {
+								enabled = 1;
+							};
+							com.apple.DataProtection = {
+								enabled = 1;
+							};
+							com.apple.Keychain = {
+								enabled = 1;
+							};
+						};
+					};
+				};
+			};
+			buildConfigurationList = F8F366AB2155D5DE00A49F89 /* Build configuration list for PBXProject "CRFHeartRate" */;
+			compatibilityVersion = "Xcode 9.3";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = F8F366A72155D5DE00A49F89;
+			productRefGroup = F8F366B12155D5DE00A49F89 /* Products */;
+			projectDirPath = "";
+			projectReferences = (
+				{
+					ProductGroup = F8F366C62155D5F300A49F89 /* Products */;
+					ProjectRef = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+				},
+				{
+					ProductGroup = F8F366D82155D60200A49F89 /* Products */;
+					ProjectRef = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
+				},
+			);
+			projectRoot = "";
+			targets = (
+				F8F366AF2155D5DE00A49F89 /* CRFHeartRate */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXReferenceProxy section */
+		F8F366D22155D5F400A49F89 /* BridgeApp.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = BridgeApp.framework;
+			remoteRef = F8F366D12155D5F400A49F89 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8F366D42155D5F400A49F89 /* BridgeAppTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = BridgeAppTests.xctest;
+			remoteRef = F8F366D32155D5F400A49F89 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8F366D62155D5F400A49F89 /* BridgeAppExample.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = BridgeAppExample.app;
+			remoteRef = F8F366D52155D5F400A49F89 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CardiorespiratoryFitness.framework;
+			remoteRef = F8F366E02155D60200A49F89 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8F366E32155D60200A49F89 /* CardiorespiratoryFitnessTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CardiorespiratoryFitnessTests.xctest;
+			remoteRef = F8F366E22155D60200A49F89 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8F366E52155D60200A49F89 /* CRFTestApp.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = CRFTestApp.app;
+			remoteRef = F8F366E42155D60200A49F89 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8F366E72155D60200A49F89 /* CRFTestAppUITests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CRFTestAppUITests.xctest;
+			remoteRef = F8F366E62155D60200A49F89 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+/* End PBXReferenceProxy section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F8F366AE2155D5DE00A49F89 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8F366BE2155D5DF00A49F89 /* LaunchScreen.storyboard in Resources */,
+				F8F366E92155D65400A49F89 /* Assets.xcassets in Resources */,
+				F8F366B92155D5DE00A49F89 /* Main.storyboard in Resources */,
+				F8F367092155DA8C00A49F89 /* crf-module.pem in Resources */,
+				F8F367072155DA4000A49F89 /* BridgeInfo.plist in Resources */,
+				F8F3670B2155DA9C00A49F89 /* BridgeInfo-private.plist in Resources */,
+				F8F3678C21597DF100A49F89 /* HeartRate_Measurement.json in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		F8F366AC2155D5DE00A49F89 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F8F366B62155D5DE00A49F89 /* MainViewController.swift in Sources */,
+				F8F366B42155D5DE00A49F89 /* AppDelegate.swift in Sources */,
+				F8F367242155DE8D00A49F89 /* ExternalIDRegistrationViewController.swift in Sources */,
+				F8258597215DADA7007E7965 /* ParticipantIDStepViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F8F366F42155D6A600A49F89 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "BridgeApp (iOS)";
+			targetProxy = F8F366F32155D6A600A49F89 /* PBXContainerItemProxy */;
+		};
+		F8F367032155D7A000A49F89 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CardiorespiratoryFitness;
+			targetProxy = F8F367022155D7A000A49F89 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		F8F366B72155D5DE00A49F89 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F8F366B82155D5DE00A49F89 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		F8F366BC2155D5DF00A49F89 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				F8F366BD2155D5DF00A49F89 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		F8F366C02155D5DF00A49F89 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		F8F366C12155D5DF00A49F89 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OPTIMIZATION_LEVEL = "-O";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		F8F366C32155D5DF00A49F89 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = CRFHeartRate/CRFHeartRate.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KA9Z8R6M6K;
+				INFOPLIST_FILE = CRFHeartRate/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.sagebase.CRFHeartRate;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Debug;
+		};
+		F8F366C42155D5DF00A49F89 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_ENTITLEMENTS = CRFHeartRate/CRFHeartRate.entitlements;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = KA9Z8R6M6K;
+				INFOPLIST_FILE = CRFHeartRate/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = org.sagebase.CRFHeartRate;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 4.2;
+				TARGETED_DEVICE_FAMILY = 1;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		F8F366AB2155D5DE00A49F89 /* Build configuration list for PBXProject "CRFHeartRate" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F8F366C02155D5DF00A49F89 /* Debug */,
+				F8F366C12155D5DF00A49F89 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F8F366C22155D5DF00A49F89 /* Build configuration list for PBXNativeTarget "CRFHeartRate" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F8F366C32155D5DF00A49F89 /* Debug */,
+				F8F366C42155D5DF00A49F89 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = F8F366A82155D5DE00A49F89 /* Project object */;
+}

--- a/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
+++ b/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F806135E215ED36E001B1574 /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */; };
+		F806135F215ED36E001B1574 /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8258597215DADA7007E7965 /* ParticipantIDStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */; };
 		F8F366B42155D5DE00A49F89 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B32155D5DE00A49F89 /* AppDelegate.swift */; };
 		F8F366B62155D5DE00A49F89 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B52155D5DE00A49F89 /* MainViewController.swift */; };
@@ -15,8 +17,6 @@
 		F8F366E92155D65400A49F89 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8F366E82155D65400A49F89 /* Assets.xcassets */; };
 		F8F366F12155D6A600A49F89 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366D22155D5F400A49F89 /* BridgeApp.framework */; };
 		F8F366F22155D6A600A49F89 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366D22155D5F400A49F89 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8F367002155D7A000A49F89 /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */; };
-		F8F367012155D7A000A49F89 /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8F367072155DA4000A49F89 /* BridgeInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8F367062155DA4000A49F89 /* BridgeInfo.plist */; };
 		F8F367092155DA8C00A49F89 /* crf-module.pem in Resources */ = {isa = PBXBuildFile; fileRef = F8F367082155DA8C00A49F89 /* crf-module.pem */; };
 		F8F3670B2155DA9C00A49F89 /* BridgeInfo-private.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8F3670A2155DA9C00A49F89 /* BridgeInfo-private.plist */; };
@@ -25,6 +25,41 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		F8061350215ED330001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F88725D92051C0F800A4B82F;
+			remoteInfo = CardiorespiratoryFitness;
+		};
+		F8061352215ED330001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F88725E22051C0F900A4B82F;
+			remoteInfo = CardiorespiratoryFitnessTests;
+		};
+		F8061354215ED330001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F8BA7FE02051DC2D00A5B83A;
+			remoteInfo = CRFTestApp;
+		};
+		F8061356215ED330001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F8BA7FF32051DC2E00A5B83A;
+			remoteInfo = CRFTestAppUITests;
+		};
+		F8061360215ED36E001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F88725D82051C0F800A4B82F;
+			remoteInfo = CardiorespiratoryFitness;
+		};
 		F8F366D12155D5F400A49F89 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
@@ -46,47 +81,12 @@
 			remoteGlobalIDString = F83B450220324A33002825AE;
 			remoteInfo = BridgeAppExample;
 		};
-		F8F366E02155D60200A49F89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F88725D92051C0F800A4B82F;
-			remoteInfo = CardiorespiratoryFitness;
-		};
-		F8F366E22155D60200A49F89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F88725E22051C0F900A4B82F;
-			remoteInfo = CardiorespiratoryFitnessTests;
-		};
-		F8F366E42155D60200A49F89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F8BA7FE02051DC2D00A5B83A;
-			remoteInfo = CRFTestApp;
-		};
-		F8F366E62155D60200A49F89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F8BA7FF32051DC2E00A5B83A;
-			remoteInfo = CRFTestAppUITests;
-		};
 		F8F366F32155D6A600A49F89 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
 			proxyType = 1;
 			remoteGlobalIDString = F83B44A42032467D002825AE;
 			remoteInfo = "BridgeApp (iOS)";
-		};
-		F8F367022155D7A000A49F89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = F88725D82051C0F800A4B82F;
-			remoteInfo = CardiorespiratoryFitness;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -97,7 +97,7 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F8F367012155D7A000A49F89 /* CardiorespiratoryFitness.framework in Embed Frameworks */,
+				F806135F215ED36E001B1574 /* CardiorespiratoryFitness.framework in Embed Frameworks */,
 				F8F366F22155D6A600A49F89 /* BridgeApp.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -106,6 +106,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CardiorespiratoryFitness.xcodeproj; path = ../CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj; sourceTree = "<group>"; };
 		F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantIDStepViewController.swift; sourceTree = "<group>"; };
 		F8F366B02155D5DE00A49F89 /* CRFHeartRate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CRFHeartRate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8F366B32155D5DE00A49F89 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -114,7 +115,6 @@
 		F8F366BD2155D5DF00A49F89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F8F366BF2155D5DF00A49F89 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeApp.xcodeproj; path = ../BridgeApp/BridgeApp/BridgeApp.xcodeproj; sourceTree = "<group>"; };
-		F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CardiorespiratoryFitness.xcodeproj; path = ../CardiorespiratoryFitness/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj; sourceTree = "<group>"; };
 		F8F366E82155D65400A49F89 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = "../../../CardiorespiratoryFitness-iOS/CardiorespiratoryFitness/CRFTestApp/Assets.xcassets"; sourceTree = "<group>"; };
 		F8F367042155D7B500A49F89 /* CRFHeartRate.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CRFHeartRate.entitlements; sourceTree = "<group>"; };
 		F8F367062155DA4000A49F89 /* BridgeInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BridgeInfo.plist; sourceTree = "<group>"; };
@@ -129,7 +129,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8F367002155D7A000A49F89 /* CardiorespiratoryFitness.framework in Frameworks */,
+				F806135E215ED36E001B1574 /* CardiorespiratoryFitness.framework in Frameworks */,
 				F8F366F12155D6A600A49F89 /* BridgeApp.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -137,6 +137,17 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F806134A215ED330001B1574 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */,
+				F8061353215ED330001B1574 /* CardiorespiratoryFitnessTests.xctest */,
+				F8061355215ED330001B1574 /* CRFTestApp.app */,
+				F8061357215ED330001B1574 /* CRFTestAppUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		F8258590215DACAB007E7965 /* Heart Rate */ = {
 			isa = PBXGroup;
 			children = (
@@ -151,8 +162,8 @@
 			children = (
 				F8F366B22155D5DE00A49F89 /* CRFHeartRate */,
 				F8F366B12155D5DE00A49F89 /* Products */,
+				F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */,
 				F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */,
-				F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */,
 			);
 			sourceTree = "<group>";
 		};
@@ -185,17 +196,6 @@
 				F8F366D22155D5F400A49F89 /* BridgeApp.framework */,
 				F8F366D42155D5F400A49F89 /* BridgeAppTests.xctest */,
 				F8F366D62155D5F400A49F89 /* BridgeAppExample.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		F8F366D82155D60200A49F89 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */,
-				F8F366E32155D60200A49F89 /* CardiorespiratoryFitnessTests.xctest */,
-				F8F366E52155D60200A49F89 /* CRFTestApp.app */,
-				F8F366E72155D60200A49F89 /* CRFTestAppUITests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -236,7 +236,7 @@
 			);
 			dependencies = (
 				F8F366F42155D6A600A49F89 /* PBXTargetDependency */,
-				F8F367032155D7A000A49F89 /* PBXTargetDependency */,
+				F8061361215ED36E001B1574 /* PBXTargetDependency */,
 			);
 			name = CRFHeartRate;
 			productName = CRFHeartRate;
@@ -289,8 +289,8 @@
 					ProjectRef = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
 				},
 				{
-					ProductGroup = F8F366D82155D60200A49F89 /* Products */;
-					ProjectRef = F8F366D72155D60200A49F89 /* CardiorespiratoryFitness.xcodeproj */;
+					ProductGroup = F806134A215ED330001B1574 /* Products */;
+					ProjectRef = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -301,6 +301,34 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
+		F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = CardiorespiratoryFitness.framework;
+			remoteRef = F8061350215ED330001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8061353215ED330001B1574 /* CardiorespiratoryFitnessTests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CardiorespiratoryFitnessTests.xctest;
+			remoteRef = F8061352215ED330001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8061355215ED330001B1574 /* CRFTestApp.app */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.application;
+			path = CRFTestApp.app;
+			remoteRef = F8061354215ED330001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8061357215ED330001B1574 /* CRFTestAppUITests.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = CRFTestAppUITests.xctest;
+			remoteRef = F8061356215ED330001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		F8F366D22155D5F400A49F89 /* BridgeApp.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
@@ -320,34 +348,6 @@
 			fileType = wrapper.application;
 			path = BridgeAppExample.app;
 			remoteRef = F8F366D52155D5F400A49F89 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8F366E12155D60200A49F89 /* CardiorespiratoryFitness.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = CardiorespiratoryFitness.framework;
-			remoteRef = F8F366E02155D60200A49F89 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8F366E32155D60200A49F89 /* CardiorespiratoryFitnessTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CardiorespiratoryFitnessTests.xctest;
-			remoteRef = F8F366E22155D60200A49F89 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8F366E52155D60200A49F89 /* CRFTestApp.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = CRFTestApp.app;
-			remoteRef = F8F366E42155D60200A49F89 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8F366E72155D60200A49F89 /* CRFTestAppUITests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CRFTestAppUITests.xctest;
-			remoteRef = F8F366E62155D60200A49F89 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -384,15 +384,15 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		F8061361215ED36E001B1574 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = CardiorespiratoryFitness;
+			targetProxy = F8061360215ED36E001B1574 /* PBXContainerItemProxy */;
+		};
 		F8F366F42155D6A600A49F89 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "BridgeApp (iOS)";
 			targetProxy = F8F366F32155D6A600A49F89 /* PBXContainerItemProxy */;
-		};
-		F8F367032155D7A000A49F89 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CardiorespiratoryFitness;
-			targetProxy = F8F367022155D7A000A49F89 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
+++ b/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
@@ -7,17 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		F806135E215ED36E001B1574 /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */; };
-		F806135F215ED36E001B1574 /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8258597215DADA7007E7965 /* ParticipantIDStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */; };
-		F8CEB92B215EE9B300B02D02 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */; };
-		F8CEB92C215EE9B300B02D02 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8CEB932215EE9C000B02D02 /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */; };
-		F8CEB933215EE9C000B02D02 /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8CEB937215EE9E700B02D02 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */; };
-		F8CEB938215EE9E700B02D02 /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8CEB93A215EE9F400B02D02 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E39215EE8D200F7FF20 /* Research.framework */; };
-		F8CEB93B215EE9F400B02D02 /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E39215EE8D200F7FF20 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8DCA3922162B6910063AE95 /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA3912162B6720063AE95 /* CardiorespiratoryFitness.framework */; };
+		F8DCA3932162B6910063AE95 /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA3912162B6720063AE95 /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8DCA3942162B6910063AE95 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA38B2162B64C0063AE95 /* BridgeApp.framework */; };
+		F8DCA3952162B6910063AE95 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA38B2162B64C0063AE95 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8DCA3962162B6910063AE95 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA37F2162B5C60063AE95 /* BridgeSDK.framework */; };
+		F8DCA3972162B6910063AE95 /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA37F2162B5C60063AE95 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8DCA3982162B6910063AE95 /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA3802162B5C60063AE95 /* ResearchUI.framework */; };
+		F8DCA3992162B6910063AE95 /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA3802162B5C60063AE95 /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8DCA39A2162B6910063AE95 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA3812162B5C60063AE95 /* Research.framework */; };
+		F8DCA39B2162B6910063AE95 /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DCA3812162B5C60063AE95 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8F366B42155D5DE00A49F89 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B32155D5DE00A49F89 /* AppDelegate.swift */; };
 		F8F366B62155D5DE00A49F89 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B52155D5DE00A49F89 /* MainViewController.swift */; };
 		F8F366B92155D5DE00A49F89 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8F366B72155D5DE00A49F89 /* Main.storyboard */; };
@@ -30,72 +30,6 @@
 		F8F3678C21597DF100A49F89 /* HeartRate_Measurement.json in Resources */ = {isa = PBXBuildFile; fileRef = F8F3678B21597DF100A49F89 /* HeartRate_Measurement.json */; };
 /* End PBXBuildFile section */
 
-/* Begin PBXContainerItemProxy section */
-		F8061350215ED330001B1574 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F88725D92051C0F800A4B82F;
-			remoteInfo = CardiorespiratoryFitness;
-		};
-		F8061352215ED330001B1574 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F88725E22051C0F900A4B82F;
-			remoteInfo = CardiorespiratoryFitnessTests;
-		};
-		F8061354215ED330001B1574 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F8BA7FE02051DC2D00A5B83A;
-			remoteInfo = CRFTestApp;
-		};
-		F8061356215ED330001B1574 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F8BA7FF32051DC2E00A5B83A;
-			remoteInfo = CRFTestAppUITests;
-		};
-		F8061360215ED36E001B1574 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = F88725D82051C0F800A4B82F;
-			remoteInfo = CardiorespiratoryFitness;
-		};
-		F8CEB92D215EE9B300B02D02 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = F83B44A42032467D002825AE;
-			remoteInfo = "BridgeApp (iOS)";
-		};
-		F8DA5E2C215EE86500F7FF20 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F83B44A52032467D002825AE;
-			remoteInfo = "BridgeApp (iOS)";
-		};
-		F8DA5E2E215EE86500F7FF20 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F83B44AE2032467D002825AE;
-			remoteInfo = BridgeAppTests;
-		};
-		F8DA5E30215EE86500F7FF20 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F83B450220324A33002825AE;
-			remoteInfo = BridgeAppExample;
-		};
-/* End PBXContainerItemProxy section */
-
 /* Begin PBXCopyFilesBuildPhase section */
 		F8F366ED2155D69400A49F89 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
@@ -103,11 +37,11 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F806135F215ED36E001B1574 /* CardiorespiratoryFitness.framework in Embed Frameworks */,
-				F8CEB93B215EE9F400B02D02 /* Research.framework in Embed Frameworks */,
-				F8CEB938215EE9E700B02D02 /* BridgeSDK.framework in Embed Frameworks */,
-				F8CEB92C215EE9B300B02D02 /* BridgeApp.framework in Embed Frameworks */,
-				F8CEB933215EE9C000B02D02 /* ResearchUI.framework in Embed Frameworks */,
+				F8DCA3932162B6910063AE95 /* CardiorespiratoryFitness.framework in Embed Frameworks */,
+				F8DCA3952162B6910063AE95 /* BridgeApp.framework in Embed Frameworks */,
+				F8DCA3972162B6910063AE95 /* BridgeSDK.framework in Embed Frameworks */,
+				F8DCA3992162B6910063AE95 /* ResearchUI.framework in Embed Frameworks */,
+				F8DCA39B2162B6910063AE95 /* Research.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -115,13 +49,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CardiorespiratoryFitness.xcodeproj; path = ../CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj; sourceTree = "<group>"; };
+		F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CardiorespiratoryFitness.xcodeproj; path = ../CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj; sourceTree = SOURCE_ROOT; };
 		F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantIDStepViewController.swift; sourceTree = "<group>"; };
-		F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F8CEB93C215EEA0500B02D02 /* BridgeSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BridgeSDK.framework; path = "../../../../Library/Developer/Xcode/DerivedData/CardiorespiratoryFitness-cxppknkrgzlqatdpxvfpdzafizqo/Build/Products/Debug-iphoneos/BridgeSDK.framework"; sourceTree = "<group>"; };
-		F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeApp.xcodeproj; path = ../BridgeApp/BridgeApp/BridgeApp.xcodeproj; sourceTree = "<group>"; };
-		F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ResearchUI.framework; path = "../../../../Library/Developer/Xcode/DerivedData/CardiorespiratoryFitness-cxppknkrgzlqatdpxvfpdzafizqo/Build/Products/Debug-iphoneos/ResearchUI.framework"; sourceTree = "<group>"; };
-		F8DA5E39215EE8D200F7FF20 /* Research.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Research.framework; path = "../../../../Library/Developer/Xcode/DerivedData/CardiorespiratoryFitness-cxppknkrgzlqatdpxvfpdzafizqo/Build/Products/Debug-iphoneos/Research.framework"; sourceTree = "<group>"; };
+		F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeApp.xcodeproj; path = ../BridgeApp/BridgeApp/BridgeApp.xcodeproj; sourceTree = SOURCE_ROOT; };
+		F8DCA37F2162B5C60063AE95 /* BridgeSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = BridgeSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8DCA3802162B5C60063AE95 /* ResearchUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = ResearchUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8DCA3812162B5C60063AE95 /* Research.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Research.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8DCA38B2162B64C0063AE95 /* BridgeApp.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = BridgeApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8DCA3912162B6720063AE95 /* CardiorespiratoryFitness.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = CardiorespiratoryFitness.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8F366B02155D5DE00A49F89 /* CRFHeartRate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CRFHeartRate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8F366B32155D5DE00A49F89 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F8F366B52155D5DE00A49F89 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
@@ -142,28 +77,17 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F806135E215ED36E001B1574 /* CardiorespiratoryFitness.framework in Frameworks */,
-				F8CEB93A215EE9F400B02D02 /* Research.framework in Frameworks */,
-				F8CEB937215EE9E700B02D02 /* BridgeSDK.framework in Frameworks */,
-				F8CEB92B215EE9B300B02D02 /* BridgeApp.framework in Frameworks */,
-				F8CEB932215EE9C000B02D02 /* ResearchUI.framework in Frameworks */,
+				F8DCA3922162B6910063AE95 /* CardiorespiratoryFitness.framework in Frameworks */,
+				F8DCA3942162B6910063AE95 /* BridgeApp.framework in Frameworks */,
+				F8DCA3962162B6910063AE95 /* BridgeSDK.framework in Frameworks */,
+				F8DCA3982162B6910063AE95 /* ResearchUI.framework in Frameworks */,
+				F8DCA39A2162B6910063AE95 /* Research.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
-		F806134A215ED330001B1574 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */,
-				F8061353215ED330001B1574 /* CardiorespiratoryFitnessTests.xctest */,
-				F8061355215ED330001B1574 /* CRFTestApp.app */,
-				F8061357215ED330001B1574 /* CRFTestAppUITests.xctest */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
 		F8258590215DACAB007E7965 /* Heart Rate */ = {
 			isa = PBXGroup;
 			children = (
@@ -176,29 +100,20 @@
 		F8DA5E19215EE83C00F7FF20 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				F8CEB93C215EEA0500B02D02 /* BridgeSDK.framework */,
-				F8DA5E39215EE8D200F7FF20 /* Research.framework */,
-				F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */,
+				F8DCA3912162B6720063AE95 /* CardiorespiratoryFitness.framework */,
+				F8DCA38B2162B64C0063AE95 /* BridgeApp.framework */,
+				F8DCA37F2162B5C60063AE95 /* BridgeSDK.framework */,
+				F8DCA3802162B5C60063AE95 /* ResearchUI.framework */,
+				F8DCA3812162B5C60063AE95 /* Research.framework */,
 				F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */,
 				F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		F8DA5E27215EE86500F7FF20 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */,
-				F8DA5E2F215EE86500F7FF20 /* BridgeAppTests.xctest */,
-				F8DA5E31215EE86500F7FF20 /* BridgeAppExample.app */,
-			);
-			name = Products;
-			sourceTree = "<group>";
+			sourceTree = SOURCE_ROOT;
 		};
 		F8F366A72155D5DE00A49F89 = {
 			isa = PBXGroup;
 			children = (
-				F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */,
 				F8F366B22155D5DE00A49F89 /* CRFHeartRate */,
 				F8DA5E19215EE83C00F7FF20 /* Frameworks */,
 				F8F366B12155D5DE00A49F89 /* Products */,
@@ -263,8 +178,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				F8061361215ED36E001B1574 /* PBXTargetDependency */,
-				F8CEB92E215EE9B300B02D02 /* PBXTargetDependency */,
 			);
 			name = CRFHeartRate;
 			productName = CRFHeartRate;
@@ -311,74 +224,12 @@
 			mainGroup = F8F366A72155D5DE00A49F89;
 			productRefGroup = F8F366B12155D5DE00A49F89 /* Products */;
 			projectDirPath = "";
-			projectReferences = (
-				{
-					ProductGroup = F8DA5E27215EE86500F7FF20 /* Products */;
-					ProjectRef = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
-				},
-				{
-					ProductGroup = F806134A215ED330001B1574 /* Products */;
-					ProjectRef = F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */;
-				},
-			);
 			projectRoot = "";
 			targets = (
 				F8F366AF2155D5DE00A49F89 /* CRFHeartRate */,
 			);
 		};
 /* End PBXProject section */
-
-/* Begin PBXReferenceProxy section */
-		F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = CardiorespiratoryFitness.framework;
-			remoteRef = F8061350215ED330001B1574 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8061353215ED330001B1574 /* CardiorespiratoryFitnessTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CardiorespiratoryFitnessTests.xctest;
-			remoteRef = F8061352215ED330001B1574 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8061355215ED330001B1574 /* CRFTestApp.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = CRFTestApp.app;
-			remoteRef = F8061354215ED330001B1574 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8061357215ED330001B1574 /* CRFTestAppUITests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = CRFTestAppUITests.xctest;
-			remoteRef = F8061356215ED330001B1574 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = BridgeApp.framework;
-			remoteRef = F8DA5E2C215EE86500F7FF20 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8DA5E2F215EE86500F7FF20 /* BridgeAppTests.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = BridgeAppTests.xctest;
-			remoteRef = F8DA5E2E215EE86500F7FF20 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8DA5E31215EE86500F7FF20 /* BridgeAppExample.app */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.application;
-			path = BridgeAppExample.app;
-			remoteRef = F8DA5E30215EE86500F7FF20 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-/* End PBXReferenceProxy section */
 
 /* Begin PBXResourcesBuildPhase section */
 		F8F366AE2155D5DE00A49F89 /* Resources */ = {
@@ -410,19 +261,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
-
-/* Begin PBXTargetDependency section */
-		F8061361215ED36E001B1574 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = CardiorespiratoryFitness;
-			targetProxy = F8061360215ED36E001B1574 /* PBXContainerItemProxy */;
-		};
-		F8CEB92E215EE9B300B02D02 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "BridgeApp (iOS)";
-			targetProxy = F8CEB92D215EE9B300B02D02 /* PBXContainerItemProxy */;
-		};
-/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		F8F366B72155D5DE00A49F89 /* Main.storyboard */ = {
@@ -563,7 +401,6 @@
 		F8F366C32155D5DF00A49F89 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CRFHeartRate/CRFHeartRate.entitlements;
 				CODE_SIGN_STYLE = Automatic;
@@ -584,7 +421,6 @@
 		F8F366C42155D5DF00A49F89 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_ENTITLEMENTS = CRFHeartRate/CRFHeartRate.entitlements;
 				CODE_SIGN_STYLE = Automatic;

--- a/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
+++ b/CRFHeartRate/CRFHeartRate.xcodeproj/project.pbxproj
@@ -10,13 +10,19 @@
 		F806135E215ED36E001B1574 /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */; };
 		F806135F215ED36E001B1574 /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8061351215ED330001B1574 /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8258597215DADA7007E7965 /* ParticipantIDStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */; };
+		F8CEB92B215EE9B300B02D02 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */; };
+		F8CEB92C215EE9B300B02D02 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8CEB932215EE9C000B02D02 /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */; };
+		F8CEB933215EE9C000B02D02 /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8CEB937215EE9E700B02D02 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */; };
+		F8CEB938215EE9E700B02D02 /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8CEB93A215EE9F400B02D02 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E39215EE8D200F7FF20 /* Research.framework */; };
+		F8CEB93B215EE9F400B02D02 /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E39215EE8D200F7FF20 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8F366B42155D5DE00A49F89 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B32155D5DE00A49F89 /* AppDelegate.swift */; };
 		F8F366B62155D5DE00A49F89 /* MainViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F366B52155D5DE00A49F89 /* MainViewController.swift */; };
 		F8F366B92155D5DE00A49F89 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8F366B72155D5DE00A49F89 /* Main.storyboard */; };
 		F8F366BE2155D5DF00A49F89 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8F366BC2155D5DF00A49F89 /* LaunchScreen.storyboard */; };
 		F8F366E92155D65400A49F89 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8F366E82155D65400A49F89 /* Assets.xcassets */; };
-		F8F366F12155D6A600A49F89 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366D22155D5F400A49F89 /* BridgeApp.framework */; };
-		F8F366F22155D6A600A49F89 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8F366D22155D5F400A49F89 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8F367072155DA4000A49F89 /* BridgeInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8F367062155DA4000A49F89 /* BridgeInfo.plist */; };
 		F8F367092155DA8C00A49F89 /* crf-module.pem in Resources */ = {isa = PBXBuildFile; fileRef = F8F367082155DA8C00A49F89 /* crf-module.pem */; };
 		F8F3670B2155DA9C00A49F89 /* BridgeInfo-private.plist in Resources */ = {isa = PBXBuildFile; fileRef = F8F3670A2155DA9C00A49F89 /* BridgeInfo-private.plist */; };
@@ -60,33 +66,33 @@
 			remoteGlobalIDString = F88725D82051C0F800A4B82F;
 			remoteInfo = CardiorespiratoryFitness;
 		};
-		F8F366D12155D5F400A49F89 /* PBXContainerItemProxy */ = {
+		F8CEB92D215EE9B300B02D02 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = F83B44A42032467D002825AE;
+			remoteInfo = "BridgeApp (iOS)";
+		};
+		F8DA5E2C215EE86500F7FF20 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F83B44A52032467D002825AE;
 			remoteInfo = "BridgeApp (iOS)";
 		};
-		F8F366D32155D5F400A49F89 /* PBXContainerItemProxy */ = {
+		F8DA5E2E215EE86500F7FF20 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F83B44AE2032467D002825AE;
 			remoteInfo = BridgeAppTests;
 		};
-		F8F366D52155D5F400A49F89 /* PBXContainerItemProxy */ = {
+		F8DA5E30215EE86500F7FF20 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+			containerPortal = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F83B450220324A33002825AE;
 			remoteInfo = BridgeAppExample;
-		};
-		F8F366F32155D6A600A49F89 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = F83B44A42032467D002825AE;
-			remoteInfo = "BridgeApp (iOS)";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -98,7 +104,10 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F806135F215ED36E001B1574 /* CardiorespiratoryFitness.framework in Embed Frameworks */,
-				F8F366F22155D6A600A49F89 /* BridgeApp.framework in Embed Frameworks */,
+				F8CEB93B215EE9F400B02D02 /* Research.framework in Embed Frameworks */,
+				F8CEB938215EE9E700B02D02 /* BridgeSDK.framework in Embed Frameworks */,
+				F8CEB92C215EE9B300B02D02 /* BridgeApp.framework in Embed Frameworks */,
+				F8CEB933215EE9C000B02D02 /* ResearchUI.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -108,13 +117,17 @@
 /* Begin PBXFileReference section */
 		F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = CardiorespiratoryFitness.xcodeproj; path = ../CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj; sourceTree = "<group>"; };
 		F8258596215DADA7007E7965 /* ParticipantIDStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipantIDStepViewController.swift; sourceTree = "<group>"; };
+		F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8CEB93C215EEA0500B02D02 /* BridgeSDK.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = BridgeSDK.framework; path = "../../../../Library/Developer/Xcode/DerivedData/CardiorespiratoryFitness-cxppknkrgzlqatdpxvfpdzafizqo/Build/Products/Debug-iphoneos/BridgeSDK.framework"; sourceTree = "<group>"; };
+		F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeApp.xcodeproj; path = ../BridgeApp/BridgeApp/BridgeApp.xcodeproj; sourceTree = "<group>"; };
+		F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ResearchUI.framework; path = "../../../../Library/Developer/Xcode/DerivedData/CardiorespiratoryFitness-cxppknkrgzlqatdpxvfpdzafizqo/Build/Products/Debug-iphoneos/ResearchUI.framework"; sourceTree = "<group>"; };
+		F8DA5E39215EE8D200F7FF20 /* Research.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Research.framework; path = "../../../../Library/Developer/Xcode/DerivedData/CardiorespiratoryFitness-cxppknkrgzlqatdpxvfpdzafizqo/Build/Products/Debug-iphoneos/Research.framework"; sourceTree = "<group>"; };
 		F8F366B02155D5DE00A49F89 /* CRFHeartRate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CRFHeartRate.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8F366B32155D5DE00A49F89 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F8F366B52155D5DE00A49F89 /* MainViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainViewController.swift; sourceTree = "<group>"; };
 		F8F366B82155D5DE00A49F89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		F8F366BD2155D5DF00A49F89 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		F8F366BF2155D5DF00A49F89 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = BridgeApp.xcodeproj; path = ../BridgeApp/BridgeApp/BridgeApp.xcodeproj; sourceTree = "<group>"; };
 		F8F366E82155D65400A49F89 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Assets.xcassets; path = "../../../CardiorespiratoryFitness-iOS/CardiorespiratoryFitness/CRFTestApp/Assets.xcassets"; sourceTree = "<group>"; };
 		F8F367042155D7B500A49F89 /* CRFHeartRate.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = CRFHeartRate.entitlements; sourceTree = "<group>"; };
 		F8F367062155DA4000A49F89 /* BridgeInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = BridgeInfo.plist; sourceTree = "<group>"; };
@@ -130,7 +143,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				F806135E215ED36E001B1574 /* CardiorespiratoryFitness.framework in Frameworks */,
-				F8F366F12155D6A600A49F89 /* BridgeApp.framework in Frameworks */,
+				F8CEB93A215EE9F400B02D02 /* Research.framework in Frameworks */,
+				F8CEB937215EE9E700B02D02 /* BridgeSDK.framework in Frameworks */,
+				F8CEB92B215EE9B300B02D02 /* BridgeApp.framework in Frameworks */,
+				F8CEB932215EE9C000B02D02 /* ResearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -157,13 +173,35 @@
 			name = "Heart Rate";
 			sourceTree = "<group>";
 		};
+		F8DA5E19215EE83C00F7FF20 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F8CEB93C215EEA0500B02D02 /* BridgeSDK.framework */,
+				F8DA5E39215EE8D200F7FF20 /* Research.framework */,
+				F8DA5E38215EE8CE00F7FF20 /* ResearchUI.framework */,
+				F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */,
+				F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		F8DA5E27215EE86500F7FF20 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */,
+				F8DA5E2F215EE86500F7FF20 /* BridgeAppTests.xctest */,
+				F8DA5E31215EE86500F7FF20 /* BridgeAppExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		F8F366A72155D5DE00A49F89 = {
 			isa = PBXGroup;
 			children = (
+				F8CEB936215EE9E700B02D02 /* BridgeSDK.framework */,
 				F8F366B22155D5DE00A49F89 /* CRFHeartRate */,
+				F8DA5E19215EE83C00F7FF20 /* Frameworks */,
 				F8F366B12155D5DE00A49F89 /* Products */,
-				F8061349215ED330001B1574 /* CardiorespiratoryFitness.xcodeproj */,
-				F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */,
 			);
 			sourceTree = "<group>";
 		};
@@ -188,16 +226,6 @@
 				F8F367052155D9B800A49F89 /* Support Files */,
 			);
 			path = CRFHeartRate;
-			sourceTree = "<group>";
-		};
-		F8F366C62155D5F300A49F89 /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F8F366D22155D5F400A49F89 /* BridgeApp.framework */,
-				F8F366D42155D5F400A49F89 /* BridgeAppTests.xctest */,
-				F8F366D62155D5F400A49F89 /* BridgeAppExample.app */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		F8F367052155D9B800A49F89 /* Support Files */ = {
@@ -235,8 +263,8 @@
 			buildRules = (
 			);
 			dependencies = (
-				F8F366F42155D6A600A49F89 /* PBXTargetDependency */,
 				F8061361215ED36E001B1574 /* PBXTargetDependency */,
+				F8CEB92E215EE9B300B02D02 /* PBXTargetDependency */,
 			);
 			name = CRFHeartRate;
 			productName = CRFHeartRate;
@@ -285,8 +313,8 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = F8F366C62155D5F300A49F89 /* Products */;
-					ProjectRef = F8F366C52155D5F300A49F89 /* BridgeApp.xcodeproj */;
+					ProductGroup = F8DA5E27215EE86500F7FF20 /* Products */;
+					ProjectRef = F8DA5E26215EE86500F7FF20 /* BridgeApp.xcodeproj */;
 				},
 				{
 					ProductGroup = F806134A215ED330001B1574 /* Products */;
@@ -329,25 +357,25 @@
 			remoteRef = F8061356215ED330001B1574 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		F8F366D22155D5F400A49F89 /* BridgeApp.framework */ = {
+		F8DA5E2D215EE86500F7FF20 /* BridgeApp.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = BridgeApp.framework;
-			remoteRef = F8F366D12155D5F400A49F89 /* PBXContainerItemProxy */;
+			remoteRef = F8DA5E2C215EE86500F7FF20 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		F8F366D42155D5F400A49F89 /* BridgeAppTests.xctest */ = {
+		F8DA5E2F215EE86500F7FF20 /* BridgeAppTests.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = BridgeAppTests.xctest;
-			remoteRef = F8F366D32155D5F400A49F89 /* PBXContainerItemProxy */;
+			remoteRef = F8DA5E2E215EE86500F7FF20 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		F8F366D62155D5F400A49F89 /* BridgeAppExample.app */ = {
+		F8DA5E31215EE86500F7FF20 /* BridgeAppExample.app */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.application;
 			path = BridgeAppExample.app;
-			remoteRef = F8F366D52155D5F400A49F89 /* PBXContainerItemProxy */;
+			remoteRef = F8DA5E30215EE86500F7FF20 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -389,10 +417,10 @@
 			name = CardiorespiratoryFitness;
 			targetProxy = F8061360215ED36E001B1574 /* PBXContainerItemProxy */;
 		};
-		F8F366F42155D6A600A49F89 /* PBXTargetDependency */ = {
+		F8CEB92E215EE9B300B02D02 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = "BridgeApp (iOS)";
-			targetProxy = F8F366F32155D6A600A49F89 /* PBXContainerItemProxy */;
+			targetProxy = F8CEB92D215EE9B300B02D02 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/CRFHeartRate/CRFHeartRate.xcodeproj/xcshareddata/xcschemes/CRFHeartRate.xcscheme
+++ b/CRFHeartRate/CRFHeartRate.xcodeproj/xcshareddata/xcschemes/CRFHeartRate.xcscheme
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1000"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "F8F366AF2155D5DE00A49F89"
+               BuildableName = "CRFHeartRate.app"
+               BlueprintName = "CRFHeartRate"
+               ReferencedContainer = "container:CRFHeartRate.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8F366AF2155D5DE00A49F89"
+            BuildableName = "CRFHeartRate.app"
+            BlueprintName = "CRFHeartRate"
+            ReferencedContainer = "container:CRFHeartRate.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8F366AF2155D5DE00A49F89"
+            BuildableName = "CRFHeartRate.app"
+            BlueprintName = "CRFHeartRate"
+            ReferencedContainer = "container:CRFHeartRate.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "F8F366AF2155D5DE00A49F89"
+            BuildableName = "CRFHeartRate.app"
+            BlueprintName = "CRFHeartRate"
+            ReferencedContainer = "container:CRFHeartRate.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/CRFHeartRate/CRFHeartRate/AppDelegate.swift
+++ b/CRFHeartRate/CRFHeartRate/AppDelegate.swift
@@ -1,0 +1,90 @@
+//
+//  AppDelegate.swift
+//  CRFHeartRate
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import BridgeApp
+import BridgeSDK
+
+@UIApplicationMain
+class AppDelegate: SBAAppDelegate, RSDTaskViewControllerDelegate {
+    
+    func showAppropriateViewController(animated: Bool) {
+        if BridgeSDK.authManager.isAuthenticated() {
+            showMainViewController(animated: animated)
+        } else {
+            showSignInViewController(animated: animated)
+        }
+    }
+    
+    override func applicationDidBecomeActive(_ application: UIApplication) {
+        super.applicationDidBecomeActive(application)
+        self.showAppropriateViewController(animated: true)
+    }
+    
+    func showMainViewController(animated: Bool) {
+        guard self.rootViewController?.state != .main else { return }
+        guard let storyboard = openStoryboard("Main"),
+            let vc = storyboard.instantiateInitialViewController()
+            else {
+                fatalError("Failed to instantiate initial view controller in the main storyboard.")
+        }
+        self.transition(to: vc, state: .main, animated: true)
+    }
+    
+    func showSignInViewController(animated: Bool) {
+        guard self.rootViewController?.state != .onboarding else { return }
+
+        let externalIDStep = ExternalIDRegistrationStep(identifier: "enterExternalID", type: "externalID")
+        var navigator = RSDConditionalStepNavigatorObject(with: [externalIDStep])
+        navigator.progressMarkers = []
+        let task = RSDTaskObject(identifier: "signin", stepNavigator: navigator)
+        let vc = RSDTaskViewController(task: task)
+        vc.delegate = self
+        self.transition(to: vc, state: .onboarding, animated: true)
+    }
+    
+    func openStoryboard(_ name: String) -> UIStoryboard? {
+        return UIStoryboard(name: name, bundle: nil)
+    }
+    
+    
+    // MARK: RSDTaskViewControllerDelegate
+    
+    func taskController(_ taskController: RSDTaskController, didFinishWith reason: RSDTaskFinishReason, error: Error?) {
+        guard BridgeSDK.authManager.isAuthenticated() else { return }
+        showAppropriateViewController(animated: true)
+    }
+    
+    func taskController(_ taskController: RSDTaskController, readyToSave taskViewModel: RSDTaskViewModel) {
+    }
+}

--- a/CRFHeartRate/CRFHeartRate/Base.lproj/LaunchScreen.storyboard
+++ b/CRFHeartRate/CRFHeartRate/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/CRFHeartRate/CRFHeartRate/Base.lproj/Main.storyboard
+++ b/CRFHeartRate/CRFHeartRate/Base.lproj/Main.storyboard
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="YE0-57-TmO">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Main View Controller-->
+        <scene sceneID="B5T-TZ-iDp">
+            <objects>
+                <viewController id="YE0-57-TmO" customClass="MainViewController" customModule="CRFHeartRate" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="xZM-PE-K5Q">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <viewLayoutGuide key="safeArea" id="rdu-mu-2vv"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0YA-NE-p7I" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="-1113" y="-36"/>
+        </scene>
+    </scenes>
+</document>

--- a/CRFHeartRate/CRFHeartRate/BridgeInfo.plist
+++ b/CRFHeartRate/CRFHeartRate/BridgeInfo.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>appGroupIdentifier</key>
+	<string>group.org.null</string>
+	<key>studyIdentifier</key>
+	<string>null</string>
+	<key>certificateName</key>
+	<string>null</string>
+	<key>appUpdateURL</key>
+	<string>https://notsupported.null</string>
+	<key>cacheDaysAhead</key>
+	<integer>10</integer>
+	<key>cacheDaysBehind</key>
+	<integer>365</integer>
+</dict>
+</plist>

--- a/CRFHeartRate/CRFHeartRate/CRFHeartRate.entitlements
+++ b/CRFHeartRate/CRFHeartRate/CRFHeartRate.entitlements
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.default-data-protection</key>
+	<string>NSFileProtectionComplete</string>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.org.sagebionetworks.CRFHeartRate</string>
+	</array>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)org.sagebionetworks.CRFHeartRate</string>
+	</array>
+</dict>
+</plist>

--- a/CRFHeartRate/CRFHeartRate/ExternalIDRegistrationViewController.swift
+++ b/CRFHeartRate/CRFHeartRate/ExternalIDRegistrationViewController.swift
@@ -1,0 +1,130 @@
+//
+//  ExternalIDRegistrationViewController.swift
+//  mPower2
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import ResearchUI
+import Research
+import BridgeSDK
+import BridgeApp
+
+class ExternalIDRegistrationStep : RSDUIStepObject, RSDFormUIStep, RSDStepViewControllerVendor {
+    
+    /// Override to return a medication tracking review step view controller.
+    open func instantiateViewController(with parent: RSDPathComponent?) -> (UIViewController & RSDStepController)? {
+        return ExternalIDRegistrationViewController(step: self, parent: parent)
+    }
+    
+    let inputFields: [RSDInputField] = {
+        let prompt = NSLocalizedString("external ID", comment: "Localized string for the external ID prompt")
+        let inputField = RSDInputFieldObject(identifier: "externalId", dataType: .base(.string), uiHint: .textfield, prompt: prompt)
+        inputField.isOptional = false
+        return [inputField]
+    }()
+    
+    required init(identifier: String, type: RSDStepType?) {
+        super.init(identifier: identifier, type: type)
+        commonInit()
+    }
+
+    required init(from decoder: Decoder) throws {
+        try super.init(from: decoder)
+        commonInit()
+    }
+    
+    private func commonInit() {
+        if self.text == nil && self.title == nil {
+            self.text = NSLocalizedString("Enter your external ID to get started.", comment: "Default text for an external ID registration step.")
+        }
+        if self.colorTheme == nil {
+            var colorTheme = RSDColorThemeElementObject(usesLightStyle: true, backgroundColorName: nil, bundleIdentifier: nil)
+            colorTheme.setColorStyle(.darkBackground, for: .header)
+            colorTheme.setColorStyle(.lightBackground, for: .body)
+            colorTheme.setColorStyle(.lightBackground, for: .footer)
+            self.colorTheme = colorTheme
+        }
+    }
+}
+
+class ExternalIDRegistrationViewController: RSDTableStepViewController {
+    
+    func signUpAndSignIn(completion: @escaping SBBNetworkManagerCompletionBlock) {
+        let externalIdResultIdentifier = "externalId"
+        guard let externalId = self.stepViewModel.taskResult.findAnswerResult(with: externalIdResultIdentifier)?.value as? String
+            else {
+                return
+        }
+        
+        let signUp: SBBSignUp = SBBSignUp()
+        signUp.checkForConsent = true
+        signUp.externalId = externalId
+        signUp.password = externalId
+        signUp.sharingScope = "all_qualified_researchers"
+        
+        if externalId.hasPrefix("TEST") {
+            signUp.dataGroups = ["test_user"]
+        }
+        
+        BridgeSDK.authManager.signUpStudyParticipant(signUp, completion: { (task, result, error) in
+            guard error == nil else {
+                completion(task, result, error)
+                return
+            }
+            
+            // we're signed up so sign in
+            BridgeSDK.authManager.signIn(withExternalId: signUp.externalId!, password: signUp.password!, completion: { (task, result, error) in
+                completion(task, result, error)
+            })
+        })
+    }
+    
+    override func goForward() {
+        guard validateAndSave()
+            else {
+                return
+        }
+        
+        self.signUpAndSignIn { (task, result, error) in
+            if error == nil || (error! as NSError).code == SBBErrorCode.serverPreconditionNotMet.rawValue {
+                DispatchQueue.main.async {
+                    super.goForward()
+                }
+            } else {
+                self.presentAlertWithOk(title: "Error attempting sign in", message: error!.localizedDescription, actionHandler: nil)
+                // TODO: emm 2018-04-25 handle error from Bridge
+                // 400 is the response for an invalid external ID
+                debugPrint("Error attempting to sign up and sign in:\n\(String(describing: error))\n\nResult:\n\(String(describing: result))")
+            }
+        }
+    }
+
+}

--- a/CRFHeartRate/CRFHeartRate/HeartRate_Measurement.json
+++ b/CRFHeartRate/CRFHeartRate/HeartRate_Measurement.json
@@ -1,0 +1,34 @@
+{
+    "identifier"        : "HeartRate Measurement",
+    "shouldHideActions" : ["goBackward", "skip", "cancel"],
+    "progressMarkers"   : [],
+    "steps"             : [
+                           {
+                           "identifier"             : "participantID",
+                           "type"                   : "form",
+                           "text"                   : "Enter Participant ID",
+                           "inputFields"    : [{
+                                                   "type": "string",
+                                                   "uiHint": "textfield",
+                                                   "textFieldOptions" : {
+                                                       "keyboardType" : "numberPad"
+                                                   }
+                                                }],
+                           "colorTheme"             : { "usesLightStyle" : true }
+                           },
+                           {
+                           "identifier"         : "heartRate",
+                           "type"               : "heartRateSection",
+                           "asyncActions"       : [
+                                                   {
+                                                       "identifier"              : "motion",
+                                                       "type"                    : "motion",
+                                                       "startStepIdentifier"     : "heartRate",
+                                                       "StopStepIdentifier"      : "heartRate",
+                                                       "requiresBackgroundAudio" : true,
+                                                       "recorderTypes"           : ["accelerometer", "gyro"]
+                                                   }
+                                               ]
+                           }
+                           ]
+}

--- a/CRFHeartRate/CRFHeartRate/Info.plist
+++ b/CRFHeartRate/CRFHeartRate/Info.plist
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+		<string>fetch</string>
+		<string>location</string>
+	</array>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>LaunchScreen</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>This application uses the camera to measure your heart rate.</string>
+	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
+	<string>This application uses GPS location to calculate the distance you travel while walking or running.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>This application uses GPS location to calculate the distance you travel while walking or running.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>This application uses your phone's motion sensors to measure steps during the 12 minute test and step height during the stair step test.</string>
+</dict>
+</plist>

--- a/CRFHeartRate/CRFHeartRate/MainViewController.swift
+++ b/CRFHeartRate/CRFHeartRate/MainViewController.swift
@@ -1,0 +1,93 @@
+//
+//  MainViewController.swift
+//  CRFHeartRate
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import ResearchUI
+import Research
+import BridgeApp
+import CardiorespiratoryFitness
+
+class MainViewController: UIViewController, RSDTaskViewControllerDelegate {
+    
+    let archiveManager = SBAArchiveManager()
+
+    /// The page view controller used to control the view controller navigation.
+    var pageViewController: UIPageViewController!
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        // Set up the page view controller
+        let pageVC = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal, options: nil)
+        pageVC.edgesForExtendedLayout = UIRectEdge(rawValue: 0)
+        self.addChild(pageVC)
+        pageVC.view.frame = self.view.bounds
+        self.view.addSubview(pageVC.view)
+        pageVC.view.rsd_alignAllToSuperview(padding: 0)
+        pageVC.didMove(toParent: self)
+        self.pageViewController = pageVC
+        
+        loadTask(false)
+    }
+
+    func loadTask(_ animated: Bool) {
+        do {
+            let taskTransformer = RSDResourceTransformerObject(resourceName: "HeartRate_Measurement.json")
+            let factory = CRFFactory()
+            let task = try factory.decodeTask(with: taskTransformer)
+            let vc = RSDTaskViewController(task: task)
+            vc.delegate = self
+            self.pageViewController.setViewControllers([vc],
+                                                       direction: UIPageViewController.NavigationDirection.forward,
+                                                       animated: animated,
+                                                       completion: nil)
+        } catch let err {
+            fatalError("Failed to decode the task. \(err)")
+        }
+    }
+    
+    func taskController(_ taskController: RSDTaskController, didFinishWith reason: RSDTaskFinishReason, error: Error?) {
+        loadTask(true)
+    }
+    
+    func taskController(_ taskController: RSDTaskController, readyToSave taskViewModel: RSDTaskViewModel) {
+        archiveManager.archiveAndUpload(taskViewModel)
+    }
+    
+    func taskViewController(_ taskViewController: UIViewController, viewControllerForStep stepModel: RSDStepViewModel) -> UIViewController? {
+        guard stepModel.step.identifier == "participantID" else { return nil }
+        let vc = ParticipantIDStepViewController(step: stepModel.step, parent: stepModel.parent)
+        return vc
+    }
+}
+

--- a/CRFHeartRate/CRFHeartRate/ParticipantIDStepViewController.swift
+++ b/CRFHeartRate/CRFHeartRate/ParticipantIDStepViewController.swift
@@ -1,0 +1,80 @@
+//
+//  ParticipantIDStepViewController.swift
+//  CRFHeartRate
+//
+//  Copyright © 2018 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import UIKit
+import ResearchUI
+import Research
+
+class ParticipantIDStepViewController: RSDTableStepViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+    override func goForward() {
+        guard validateAndSave() else { return }
+        guard let collectionResult = self.stepViewModel.findStepResult() as? RSDCollectionResult,
+            let answerResult = collectionResult.inputResults.first as? RSDAnswerResult,
+            let participantID = answerResult.value as? String
+            else {
+                fatalError("Attempting to go forward without an answer result.")
+        }
+        guard !UserDefaults.standard.bool(forKey: participantID)
+            else {
+                handlePreviouslyUsed(participantID)
+                return
+        }
+        
+        UserDefaults.standard.set(true, forKey: participantID)
+        super.goForward()
+    }
+    
+    func handlePreviouslyUsed(_ participantID: String) {
+        self.presentAlertWithOk(title: nil, message: "ID \(participantID) has already been used on this phone.") { (_) in
+            self.clearAnswers()
+        }
+    }
+    
+    func clearAnswers() {
+        do {
+            let indexPath = IndexPath(item: 0, section: 0)
+            try self.tableData!.saveAnswer(NSNull(), at: indexPath)
+            self.refreshAnswer(at: indexPath)
+        }
+        catch let err {
+            debugPrint("Failed to save null answer: \(err)")
+        }
+    }
+}

--- a/CardiorespiratoryFitness.xcworkspace/contents.xcworkspacedata
+++ b/CardiorespiratoryFitness.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "group:BridgeApp/BridgeApp/BridgeApp.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj">
+   </FileRef>
+   <FileRef
+      location = "group:CardiorespiratoryFitness/../CRFHeartRate/CRFHeartRate.xcodeproj">
+   </FileRef>
+</Workspace>

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
@@ -56,10 +56,6 @@
 		F8BA80132051DF7800A5B83A /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88725D92051C0F800A4B82F /* CardiorespiratoryFitness.framework */; };
 		F8BA80142051DF7800A5B83A /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F88725D92051C0F800A4B82F /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8DA5E0A215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8DA5E09215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings */; };
-		F8DA5E33215EE89800F7FF20 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */; };
-		F8DA5E34215EE89800F7FF20 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8DA5E3D215EE93E00F7FF20 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */; };
-		F8DA5E3E215EE93E00F7FF20 /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8E4B5052060728F000E53D4 /* CRFArchiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E4B5042060728F000E53D4 /* CRFArchiveManager.swift */; };
 		F8F3678121596A8400A49F89 /* CRFHeartRateTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F3678021596A8400A49F89 /* CRFHeartRateTransformer.swift */; };
 /* End PBXBuildFile section */
@@ -180,8 +176,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F8BA80142051DF7800A5B83A /* CardiorespiratoryFitness.framework in Embed Frameworks */,
-				F8DA5E3E215EE93E00F7FF20 /* BridgeSDK.framework in Embed Frameworks */,
-				F8DA5E34215EE89800F7FF20 /* BridgeApp.framework in Embed Frameworks */,
 				F8061344215ED170001B1574 /* Research.framework in Embed Frameworks */,
 				F8061340215ED166001B1574 /* ResearchUI.framework in Embed Frameworks */,
 			);
@@ -243,8 +237,6 @@
 		F8BA80042051DCFC00A5B83A /* FileResultViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileResultViewController.swift; sourceTree = "<group>"; };
 		F8BA80062051DD0800A5B83A /* ResultTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTableViewController.swift; sourceTree = "<group>"; };
 		F8DA5E09215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = CardiorespiratoryFitness.strings; sourceTree = "<group>"; };
-		F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8E4B5042060728F000E53D4 /* CRFArchiveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFArchiveManager.swift; sourceTree = "<group>"; };
 		F8F3678021596A8400A49F89 /* CRFHeartRateTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFHeartRateTransformer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -275,9 +267,7 @@
 				F8061343215ED170001B1574 /* Research.framework in Frameworks */,
 				F880C17B2051FE6300ACB4D4 /* CoreLocation.framework in Frameworks */,
 				F880C1792051FE5900ACB4D4 /* CoreMotion.framework in Frameworks */,
-				F8DA5E33215EE89800F7FF20 /* BridgeApp.framework in Frameworks */,
 				F8BA80132051DF7800A5B83A /* CardiorespiratoryFitness.framework in Frameworks */,
-				F8DA5E3D215EE93E00F7FF20 /* BridgeSDK.framework in Frameworks */,
 				F806133F215ED166001B1574 /* ResearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -403,8 +393,6 @@
 		F88725CF2051C0F800A4B82F = {
 			isa = PBXGroup;
 			children = (
-				F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */,
-				F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */,
 				F88725DB2051C0F800A4B82F /* CardiorespiratoryFitness */,
 				F88725E62051C0F900A4B82F /* CardiorespiratoryFitnessTests */,
 				F8BA7FE12051DC2E00A5B83A /* CRFTestApp */,

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
@@ -55,6 +55,11 @@
 		F8BA80072051DD0800A5B83A /* ResultTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BA80062051DD0800A5B83A /* ResultTableViewController.swift */; };
 		F8BA80132051DF7800A5B83A /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88725D92051C0F800A4B82F /* CardiorespiratoryFitness.framework */; };
 		F8BA80142051DF7800A5B83A /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F88725D92051C0F800A4B82F /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8DA5E0A215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings in Resources */ = {isa = PBXBuildFile; fileRef = F8DA5E09215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings */; };
+		F8DA5E33215EE89800F7FF20 /* BridgeApp.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */; };
+		F8DA5E34215EE89800F7FF20 /* BridgeApp.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8DA5E3D215EE93E00F7FF20 /* BridgeSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */; };
+		F8DA5E3E215EE93E00F7FF20 /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8E4B5052060728F000E53D4 /* CRFArchiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E4B5042060728F000E53D4 /* CRFArchiveManager.swift */; };
 		F8F3678121596A8400A49F89 /* CRFHeartRateTransformer.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8F3678021596A8400A49F89 /* CRFHeartRateTransformer.swift */; };
 /* End PBXBuildFile section */
@@ -175,6 +180,8 @@
 			dstSubfolderSpec = 10;
 			files = (
 				F8BA80142051DF7800A5B83A /* CardiorespiratoryFitness.framework in Embed Frameworks */,
+				F8DA5E3E215EE93E00F7FF20 /* BridgeSDK.framework in Embed Frameworks */,
+				F8DA5E34215EE89800F7FF20 /* BridgeApp.framework in Embed Frameworks */,
 				F8061344215ED170001B1574 /* Research.framework in Embed Frameworks */,
 				F8061340215ED166001B1574 /* ResearchUI.framework in Embed Frameworks */,
 			);
@@ -235,6 +242,9 @@
 		F8BA80002051DCAE00A5B83A /* TaskTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskTableViewController.swift; sourceTree = "<group>"; };
 		F8BA80042051DCFC00A5B83A /* FileResultViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FileResultViewController.swift; sourceTree = "<group>"; };
 		F8BA80062051DD0800A5B83A /* ResultTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultTableViewController.swift; sourceTree = "<group>"; };
+		F8DA5E09215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; path = CardiorespiratoryFitness.strings; sourceTree = "<group>"; };
+		F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeApp.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8E4B5042060728F000E53D4 /* CRFArchiveManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFArchiveManager.swift; sourceTree = "<group>"; };
 		F8F3678021596A8400A49F89 /* CRFHeartRateTransformer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFHeartRateTransformer.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -265,7 +275,9 @@
 				F8061343215ED170001B1574 /* Research.framework in Frameworks */,
 				F880C17B2051FE6300ACB4D4 /* CoreLocation.framework in Frameworks */,
 				F880C1792051FE5900ACB4D4 /* CoreMotion.framework in Frameworks */,
+				F8DA5E33215EE89800F7FF20 /* BridgeApp.framework in Frameworks */,
 				F8BA80132051DF7800A5B83A /* CardiorespiratoryFitness.framework in Frameworks */,
+				F8DA5E3D215EE93E00F7FF20 /* BridgeSDK.framework in Frameworks */,
 				F806133F215ED166001B1574 /* ResearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -373,6 +385,7 @@
 				F880C16A2051FCD400ACB4D4 /* Cardio_Stair_Step.json */,
 				F80D31F921546A0B00E881CB /* HeartRate_Only.json */,
 				F880C16C2051FCD400ACB4D4 /* HeartrateStep.json */,
+				F8DA5E09215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings */,
 				F880C1702051FCD400ACB4D4 /* Cardio_12MT.html */,
 				F880C16F2051FCD400ACB4D4 /* Stair_Step.html */,
 			);
@@ -390,6 +403,8 @@
 		F88725CF2051C0F800A4B82F = {
 			isa = PBXGroup;
 			children = (
+				F8DA5E3C215EE93E00F7FF20 /* BridgeSDK.framework */,
+				F8DA5E32215EE89800F7FF20 /* BridgeApp.framework */,
 				F88725DB2051C0F800A4B82F /* CardiorespiratoryFitness */,
 				F88725E62051C0F900A4B82F /* CardiorespiratoryFitnessTests */,
 				F8BA7FE12051DC2E00A5B83A /* CRFTestApp */,
@@ -720,6 +735,7 @@
 				F880C1772051FCD400ACB4D4 /* Cardio_12MT.html in Resources */,
 				F880C1732051FCD400ACB4D4 /* HeartrateStep.json in Resources */,
 				F880C1762051FCD400ACB4D4 /* Stair_Step.html in Resources */,
+				F8DA5E0A215EDC0A00F7FF20 /* CardiorespiratoryFitness.strings in Resources */,
 				F80D320321546A0B00E881CB /* HeartRate_Only.json in Resources */,
 				F880C1742051FCD400ACB4D4 /* Cardio_12MT.json in Resources */,
 				F880C1312051F49400ACB4D4 /* Colors.xcassets in Resources */,

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj/project.pbxproj
@@ -7,6 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F806133D215ED0D5001B1574 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8061332215ED0B0001B1574 /* Research.framework */; };
+		F806133E215ED0D5001B1574 /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8061322215ED0AA001B1574 /* ResearchUI.framework */; };
+		F806133F215ED166001B1574 /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8061322215ED0AA001B1574 /* ResearchUI.framework */; };
+		F8061340215ED166001B1574 /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8061322215ED0AA001B1574 /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		F8061343215ED170001B1574 /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8061332215ED0B0001B1574 /* Research.framework */; };
+		F8061344215ED170001B1574 /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8061332215ED0B0001B1574 /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F80D320321546A0B00E881CB /* HeartRate_Only.json in Resources */ = {isa = PBXBuildFile; fileRef = F80D31F921546A0B00E881CB /* HeartRate_Only.json */; };
 		F82AE7F52064274A00952D74 /* UIColor+CRFDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F82AE7F42064274A00952D74 /* UIColor+CRFDefaults.swift */; };
 		F880C1202051F1E200ACB4D4 /* CRFFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = F880C11F2051F1E200ACB4D4 /* CRFFactory.swift */; };
@@ -39,8 +45,6 @@
 		F89FFDD920588B5C0089D8A7 /* ModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89FFDD820588B5C0089D8A7 /* ModelTests.swift */; };
 		F89FFDDB205890F80089D8A7 /* CRFTaskInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = F89FFDDA205890F80089D8A7 /* CRFTaskInfo.swift */; };
 		F89FFDE02059CF2C0089D8A7 /* NSLocale+UnitTest.m in Sources */ = {isa = PBXBuildFile; fileRef = F89FFDDF2059CF2C0089D8A7 /* NSLocale+UnitTest.m */; };
-		F8BA7FD22051DABF00A5B83A /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8BA7FCD2051DA9000A5B83A /* ResearchUI.framework */; };
-		F8BA7FD32051DAC700A5B83A /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8BA7FBC2051DA7C00A5B83A /* Research.framework */; };
 		F8BA7FE32051DC2E00A5B83A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BA7FE22051DC2E00A5B83A /* AppDelegate.swift */; };
 		F8BA7FE82051DC2E00A5B83A /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = F8BA7FE62051DC2E00A5B83A /* Main.storyboard */; };
 		F8BA7FEA2051DC2E00A5B83A /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8BA7FE92051DC2E00A5B83A /* Assets.xcassets */; };
@@ -49,10 +53,6 @@
 		F8BA80012051DCAE00A5B83A /* TaskTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BA80002051DCAE00A5B83A /* TaskTableViewController.swift */; };
 		F8BA80052051DCFC00A5B83A /* FileResultViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BA80042051DCFC00A5B83A /* FileResultViewController.swift */; };
 		F8BA80072051DD0800A5B83A /* ResultTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8BA80062051DD0800A5B83A /* ResultTableViewController.swift */; };
-		F8BA800A2051DF6C00A5B83A /* ResearchUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8BA7FCD2051DA9000A5B83A /* ResearchUI.framework */; };
-		F8BA800B2051DF6C00A5B83A /* ResearchUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8BA7FCD2051DA9000A5B83A /* ResearchUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		F8BA800F2051DF7100A5B83A /* Research.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8BA7FBC2051DA7C00A5B83A /* Research.framework */; };
-		F8BA80102051DF7100A5B83A /* Research.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F8BA7FBC2051DA7C00A5B83A /* Research.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8BA80132051DF7800A5B83A /* CardiorespiratoryFitness.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F88725D92051C0F800A4B82F /* CardiorespiratoryFitness.framework */; };
 		F8BA80142051DF7800A5B83A /* CardiorespiratoryFitness.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = F88725D92051C0F800A4B82F /* CardiorespiratoryFitness.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		F8E4B5052060728F000E53D4 /* CRFArchiveManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8E4B5042060728F000E53D4 /* CRFArchiveManager.swift */; };
@@ -60,12 +60,82 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		F87557D020811CA900235078 /* PBXContainerItemProxy */ = {
+		F8061321215ED0AA001B1574 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
+			containerPortal = F806131A215ED0AA001B1574 /* ResearchUI.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FFF2D9381FCF415E007258F8;
+			remoteInfo = "ResearchUI (iOS)";
+		};
+		F8061323215ED0AA001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F806131A215ED0AA001B1574 /* ResearchUI.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FFF2D9401FCF415E007258F8;
+			remoteInfo = ResearchUITests_iOS;
+		};
+		F8061325215ED0AA001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F806131A215ED0AA001B1574 /* ResearchUI.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FFF2D9701FCF41BF007258F8;
+			remoteInfo = "ResearchUI (watchOS)";
+		};
+		F8061331215ED0B0001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FF8B53141FCE678E006B6937;
+			remoteInfo = "Research (iOS)";
+		};
+		F8061333215ED0B0001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FF8B53301FCE67AA006B6937;
+			remoteInfo = "Research (watchOS)";
+		};
+		F8061335215ED0B0001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FF8B533D1FCE67C7006B6937;
+			remoteInfo = "Research (tvOS)";
+		};
+		F8061337215ED0B0001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = F8BE123521370931000AAB1E;
+			remoteInfo = "Research (macOS)";
+		};
+		F8061339215ED0B0001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = FF8B531C1FCE678E006B6937;
+			remoteInfo = ResearchTests_iOS;
+		};
+		F806133B215ED0B0001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
 			proxyType = 2;
 			remoteGlobalIDString = F875575620807E2300235078;
 			remoteInfo = "Research-UnitTest";
+		};
+		F8061341215ED166001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F806131A215ED0AA001B1574 /* ResearchUI.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = FFF2D9371FCF415E007258F8;
+			remoteInfo = "ResearchUI (iOS)";
+		};
+		F8061345215ED170001B1574 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
+			proxyType = 1;
+			remoteGlobalIDString = FF8B53131FCE678E006B6937;
+			remoteInfo = "Research (iOS)";
 		};
 		F880C1862053106500ACB4D4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -81,55 +151,6 @@
 			remoteGlobalIDString = F88725D82051C0F800A4B82F;
 			remoteInfo = CardiorespiratoryFitness;
 		};
-		F8BA7FBB2051DA7C00A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FF8B53141FCE678E006B6937;
-			remoteInfo = "Research (iOS)";
-		};
-		F8BA7FBD2051DA7C00A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FF8B531C1FCE678E006B6937;
-			remoteInfo = ResearchTests_iOS;
-		};
-		F8BA7FBF2051DA7C00A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FF8B53301FCE67AA006B6937;
-			remoteInfo = "Research (watchOS)";
-		};
-		F8BA7FC12051DA7C00A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FF8B533D1FCE67C7006B6937;
-			remoteInfo = "Research (tvOS)";
-		};
-		F8BA7FCC2051DA9000A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FC52051DA8F00A5B83A /* ResearchUI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FFF2D9381FCF415E007258F8;
-			remoteInfo = "ResearchUI (iOS)";
-		};
-		F8BA7FCE2051DA9000A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FC52051DA8F00A5B83A /* ResearchUI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FFF2D9401FCF415E007258F8;
-			remoteInfo = ResearchUITests_iOS;
-		};
-		F8BA7FD02051DA9000A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FC52051DA8F00A5B83A /* ResearchUI.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = FFF2D9701FCF41BF007258F8;
-			remoteInfo = "ResearchUI (watchOS)";
-		};
 		F8BA7FF42051DC2E00A5B83A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F88725D02051C0F800A4B82F /* Project object */;
@@ -137,33 +158,12 @@
 			remoteGlobalIDString = F8BA7FDF2051DC2D00A5B83A;
 			remoteInfo = CRFTestApp;
 		};
-		F8BA800C2051DF6C00A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FC52051DA8F00A5B83A /* ResearchUI.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = FFF2D9371FCF415E007258F8;
-			remoteInfo = "ResearchUI (iOS)";
-		};
-		F8BA80112051DF7100A5B83A /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
-			proxyType = 1;
-			remoteGlobalIDString = FF8B53131FCE678E006B6937;
-			remoteInfo = "Research (iOS)";
-		};
 		F8BA80152051DF7800A5B83A /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = F88725D02051C0F800A4B82F /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = F88725D82051C0F800A4B82F;
 			remoteInfo = CardiorespiratoryFitness;
-		};
-		F8EC751E2152C56100B529B3 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
-			proxyType = 2;
-			remoteGlobalIDString = F8BE123521370931000AAB1E;
-			remoteInfo = "Research (macOS)";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -174,9 +174,9 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				F8BA80102051DF7100A5B83A /* Research.framework in Embed Frameworks */,
 				F8BA80142051DF7800A5B83A /* CardiorespiratoryFitness.framework in Embed Frameworks */,
-				F8BA800B2051DF6C00A5B83A /* ResearchUI.framework in Embed Frameworks */,
+				F8061344215ED170001B1574 /* Research.framework in Embed Frameworks */,
+				F8061340215ED166001B1574 /* ResearchUI.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -184,6 +184,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F806131A215ED0AA001B1574 /* ResearchUI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchUI.xcodeproj; path = ../BridgeApp/SageResearch/ResearchUI/ResearchUI.xcodeproj; sourceTree = "<group>"; };
+		F8061327215ED0B0001B1574 /* Research.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Research.xcodeproj; path = ../BridgeApp/SageResearch/Research/Research.xcodeproj; sourceTree = "<group>"; };
 		F80D31F921546A0B00E881CB /* HeartRate_Only.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = HeartRate_Only.json; sourceTree = "<group>"; };
 		F82AE7F42064274A00952D74 /* UIColor+CRFDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIColor+CRFDefaults.swift"; sourceTree = "<group>"; };
 		F880C11F2051F1E200ACB4D4 /* CRFFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFFactory.swift; sourceTree = "<group>"; };
@@ -221,8 +223,6 @@
 		F89FFDDD2059CF2B0089D8A7 /* CardiorespiratoryFitnessTests-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CardiorespiratoryFitnessTests-Bridging-Header.h"; sourceTree = "<group>"; };
 		F89FFDDE2059CF2C0089D8A7 /* NSLocale+UnitTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSLocale+UnitTest.h"; sourceTree = "<group>"; };
 		F89FFDDF2059CF2C0089D8A7 /* NSLocale+UnitTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSLocale+UnitTest.m"; sourceTree = "<group>"; };
-		F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = Research.xcodeproj; path = ../SageResearch/Research/Research.xcodeproj; sourceTree = "<group>"; };
-		F8BA7FC52051DA8F00A5B83A /* ResearchUI.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = ResearchUI.xcodeproj; path = ../SageResearch/ResearchUI/ResearchUI.xcodeproj; sourceTree = "<group>"; };
 		F8BA7FE02051DC2D00A5B83A /* CRFTestApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = CRFTestApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8BA7FE22051DC2E00A5B83A /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		F8BA7FE72051DC2E00A5B83A /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -244,8 +244,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F8BA7FD32051DAC700A5B83A /* Research.framework in Frameworks */,
-				F8BA7FD22051DABF00A5B83A /* ResearchUI.framework in Frameworks */,
+				F806133D215ED0D5001B1574 /* Research.framework in Frameworks */,
+				F806133E215ED0D5001B1574 /* ResearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,11 +262,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				F880C17D2051FE7000ACB4D4 /* AVFoundation.framework in Frameworks */,
+				F8061343215ED170001B1574 /* Research.framework in Frameworks */,
 				F880C17B2051FE6300ACB4D4 /* CoreLocation.framework in Frameworks */,
 				F880C1792051FE5900ACB4D4 /* CoreMotion.framework in Frameworks */,
-				F8BA800F2051DF7100A5B83A /* Research.framework in Frameworks */,
 				F8BA80132051DF7800A5B83A /* CardiorespiratoryFitness.framework in Frameworks */,
-				F8BA800A2051DF6C00A5B83A /* ResearchUI.framework in Frameworks */,
+				F806133F215ED166001B1574 /* ResearchUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -280,6 +280,29 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		F806131B215ED0AA001B1574 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8061322215ED0AA001B1574 /* ResearchUI.framework */,
+				F8061324215ED0AA001B1574 /* ResearchUITests_iOS.xctest */,
+				F8061326215ED0AA001B1574 /* ResearchUI.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		F8061328215ED0B0001B1574 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				F8061332215ED0B0001B1574 /* Research.framework */,
+				F8061334215ED0B0001B1574 /* Research.framework */,
+				F8061336215ED0B0001B1574 /* Research.framework */,
+				F8061338215ED0B0001B1574 /* Research.framework */,
+				F806133A215ED0B0001B1574 /* ResearchTests_iOS.xctest */,
+				F806133C215ED0B0001B1574 /* Research_UnitTest.framework */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
 		F82AE7EB2064270100952D74 /* Styleguide */ = {
 			isa = PBXGroup;
 			children = (
@@ -425,36 +448,13 @@
 		F8BA7FA42051D9CC00A5B83A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				F8061327215ED0B0001B1574 /* Research.xcodeproj */,
+				F806131A215ED0AA001B1574 /* ResearchUI.xcodeproj */,
 				F880C17C2051FE7000ACB4D4 /* AVFoundation.framework */,
 				F880C17A2051FE6200ACB4D4 /* CoreLocation.framework */,
 				F880C1782051FE5900ACB4D4 /* CoreMotion.framework */,
-				F8BA7FC52051DA8F00A5B83A /* ResearchUI.xcodeproj */,
-				F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */,
 			);
 			name = Frameworks;
-			sourceTree = "<group>";
-		};
-		F8BA7FB32051DA7C00A5B83A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F8BA7FBC2051DA7C00A5B83A /* Research.framework */,
-				F8BA7FC02051DA7C00A5B83A /* Research.framework */,
-				F8BA7FC22051DA7C00A5B83A /* Research.framework */,
-				F8EC751F2152C56100B529B3 /* Research.framework */,
-				F8BA7FBE2051DA7C00A5B83A /* ResearchTests_iOS.xctest */,
-				F87557D120811CA900235078 /* Research_UnitTest.framework */,
-			);
-			name = Products;
-			sourceTree = "<group>";
-		};
-		F8BA7FC62051DA8F00A5B83A /* Products */ = {
-			isa = PBXGroup;
-			children = (
-				F8BA7FCD2051DA9000A5B83A /* ResearchUI.framework */,
-				F8BA7FCF2051DA9000A5B83A /* ResearchUITests_iOS.xctest */,
-				F8BA7FD12051DA9000A5B83A /* ResearchUI.framework */,
-			);
-			name = Products;
 			sourceTree = "<group>";
 		};
 		F8BA7FE12051DC2E00A5B83A /* CRFTestApp */ = {
@@ -546,9 +546,9 @@
 			buildRules = (
 			);
 			dependencies = (
-				F8BA800D2051DF6C00A5B83A /* PBXTargetDependency */,
-				F8BA80122051DF7100A5B83A /* PBXTargetDependency */,
 				F8BA80162051DF7800A5B83A /* PBXTargetDependency */,
+				F8061342215ED166001B1574 /* PBXTargetDependency */,
+				F8061346215ED170001B1574 /* PBXTargetDependency */,
 			);
 			name = CRFTestApp;
 			productName = CRFTestApp;
@@ -625,12 +625,12 @@
 			projectDirPath = "";
 			projectReferences = (
 				{
-					ProductGroup = F8BA7FB32051DA7C00A5B83A /* Products */;
-					ProjectRef = F8BA7FB22051DA7C00A5B83A /* Research.xcodeproj */;
+					ProductGroup = F8061328215ED0B0001B1574 /* Products */;
+					ProjectRef = F8061327215ED0B0001B1574 /* Research.xcodeproj */;
 				},
 				{
-					ProductGroup = F8BA7FC62051DA8F00A5B83A /* Products */;
-					ProjectRef = F8BA7FC52051DA8F00A5B83A /* ResearchUI.xcodeproj */;
+					ProductGroup = F806131B215ED0AA001B1574 /* Products */;
+					ProjectRef = F806131A215ED0AA001B1574 /* ResearchUI.xcodeproj */;
 				},
 			);
 			projectRoot = "";
@@ -644,67 +644,67 @@
 /* End PBXProject section */
 
 /* Begin PBXReferenceProxy section */
-		F87557D120811CA900235078 /* Research_UnitTest.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Research_UnitTest.framework;
-			remoteRef = F87557D020811CA900235078 /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8BA7FBC2051DA7C00A5B83A /* Research.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Research.framework;
-			remoteRef = F8BA7FBB2051DA7C00A5B83A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8BA7FBE2051DA7C00A5B83A /* ResearchTests_iOS.xctest */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.cfbundle;
-			path = ResearchTests_iOS.xctest;
-			remoteRef = F8BA7FBD2051DA7C00A5B83A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8BA7FC02051DA7C00A5B83A /* Research.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Research.framework;
-			remoteRef = F8BA7FBF2051DA7C00A5B83A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8BA7FC22051DA7C00A5B83A /* Research.framework */ = {
-			isa = PBXReferenceProxy;
-			fileType = wrapper.framework;
-			path = Research.framework;
-			remoteRef = F8BA7FC12051DA7C00A5B83A /* PBXContainerItemProxy */;
-			sourceTree = BUILT_PRODUCTS_DIR;
-		};
-		F8BA7FCD2051DA9000A5B83A /* ResearchUI.framework */ = {
+		F8061322215ED0AA001B1574 /* ResearchUI.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = ResearchUI.framework;
-			remoteRef = F8BA7FCC2051DA9000A5B83A /* PBXContainerItemProxy */;
+			remoteRef = F8061321215ED0AA001B1574 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		F8BA7FCF2051DA9000A5B83A /* ResearchUITests_iOS.xctest */ = {
+		F8061324215ED0AA001B1574 /* ResearchUITests_iOS.xctest */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.cfbundle;
 			path = ResearchUITests_iOS.xctest;
-			remoteRef = F8BA7FCE2051DA9000A5B83A /* PBXContainerItemProxy */;
+			remoteRef = F8061323215ED0AA001B1574 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		F8BA7FD12051DA9000A5B83A /* ResearchUI.framework */ = {
+		F8061326215ED0AA001B1574 /* ResearchUI.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = ResearchUI.framework;
-			remoteRef = F8BA7FD02051DA9000A5B83A /* PBXContainerItemProxy */;
+			remoteRef = F8061325215ED0AA001B1574 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
-		F8EC751F2152C56100B529B3 /* Research.framework */ = {
+		F8061332215ED0B0001B1574 /* Research.framework */ = {
 			isa = PBXReferenceProxy;
 			fileType = wrapper.framework;
 			path = Research.framework;
-			remoteRef = F8EC751E2152C56100B529B3 /* PBXContainerItemProxy */;
+			remoteRef = F8061331215ED0B0001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8061334215ED0B0001B1574 /* Research.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Research.framework;
+			remoteRef = F8061333215ED0B0001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8061336215ED0B0001B1574 /* Research.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Research.framework;
+			remoteRef = F8061335215ED0B0001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F8061338215ED0B0001B1574 /* Research.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Research.framework;
+			remoteRef = F8061337215ED0B0001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F806133A215ED0B0001B1574 /* ResearchTests_iOS.xctest */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.cfbundle;
+			path = ResearchTests_iOS.xctest;
+			remoteRef = F8061339215ED0B0001B1574 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		F806133C215ED0B0001B1574 /* Research_UnitTest.framework */ = {
+			isa = PBXReferenceProxy;
+			fileType = wrapper.framework;
+			path = Research_UnitTest.framework;
+			remoteRef = F806133B215ED0B0001B1574 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 /* End PBXReferenceProxy section */
@@ -808,6 +808,16 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		F8061342215ED166001B1574 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "ResearchUI (iOS)";
+			targetProxy = F8061341215ED166001B1574 /* PBXContainerItemProxy */;
+		};
+		F8061346215ED170001B1574 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = "Research (iOS)";
+			targetProxy = F8061345215ED170001B1574 /* PBXContainerItemProxy */;
+		};
 		F880C1872053106500ACB4D4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = F8BA7FDF2051DC2D00A5B83A /* CRFTestApp */;
@@ -822,16 +832,6 @@
 			isa = PBXTargetDependency;
 			target = F8BA7FDF2051DC2D00A5B83A /* CRFTestApp */;
 			targetProxy = F8BA7FF42051DC2E00A5B83A /* PBXContainerItemProxy */;
-		};
-		F8BA800D2051DF6C00A5B83A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "ResearchUI (iOS)";
-			targetProxy = F8BA800C2051DF6C00A5B83A /* PBXContainerItemProxy */;
-		};
-		F8BA80122051DF7100A5B83A /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = "Research (iOS)";
-			targetProxy = F8BA80112051DF7100A5B83A /* PBXContainerItemProxy */;
 		};
 		F8BA80162051DF7800A5B83A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/ActiveTaskSteps.storyboard
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/ActiveTaskSteps.storyboard
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_0" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
-        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14283.14"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -31,7 +30,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="320" height="286"/>
                                         <subviews>
                                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="12MinSmall1" translatesAutoresizingMaskIntoConstraints="NO" id="XnQ-38-fPg">
-                                                <rect key="frame" x="0.5" y="0.0" width="319" height="285.5"/>
+                                                <rect key="frame" x="0.5" y="0.0" width="319" height="286"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" priority="800" constant="336" id="8AE-sH-gTu"/>
                                                     <constraint firstAttribute="width" secondItem="XnQ-38-fPg" secondAttribute="height" multiplier="125:112" id="lGg-sy-5bw"/>
@@ -69,7 +68,7 @@
                                                 </connections>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Step 1 of 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Km-F7-GbV">
-                                                <rect key="frame" x="122.5" y="28" width="76" height="17"/>
+                                                <rect key="frame" x="122" y="28" width="76" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <nil key="highlightedColor"/>
@@ -111,7 +110,7 @@
                                 <rect key="frame" x="0.0" y="318" width="320" height="250"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x6H-Hm-IgM">
-                                        <rect key="frame" x="120.5" y="133" width="80.5" height="80"/>
+                                        <rect key="frame" x="120" y="133" width="80" height="80"/>
                                         <constraints>
                                             <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="80" id="Znn-wr-ES5"/>
                                             <constraint firstAttribute="height" priority="750" constant="136" id="lZE-X5-oEh"/>
@@ -195,10 +194,10 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="FB0-QG-3wZ" userLabel="Header" customClass="RSDStepHeaderView" customModule="ResearchUI">
-                                <rect key="frame" x="0.0" y="20" width="320" height="319.5"/>
+                                <rect key="frame" x="0.0" y="20" width="320" height="337.5"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="250" image="goOutsideIcon" translatesAutoresizingMaskIntoConstraints="NO" id="Thv-f8-10O">
-                                        <rect key="frame" x="0.0" y="55" width="320" height="264"/>
+                                        <rect key="frame" x="0.0" y="55" width="320" height="282.5"/>
                                     </imageView>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H5r-qp-jJ9">
                                         <rect key="frame" x="16" y="10" width="32" height="32"/>
@@ -232,7 +231,7 @@
                                         </connections>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Step 1 of 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xIK-lt-PtL">
-                                        <rect key="frame" x="122.5" y="38" width="76" height="17"/>
+                                        <rect key="frame" x="122" y="38" width="76" height="17"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                         <nil key="highlightedColor"/>
@@ -264,7 +263,7 @@
                                 <color key="backgroundColor" red="1" green="0.0" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="d3V-tc-vJS" customClass="RSDNavigationFooterView" customModule="ResearchUI">
-                                <rect key="frame" x="0.0" y="339.5" width="320" height="228.5"/>
+                                <rect key="frame" x="0.0" y="357.5" width="320" height="210.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="1000" text="Go Outside" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="mDr-qr-MOl">
                                         <rect key="frame" x="20" y="8" width="280" height="29"/>
@@ -279,7 +278,7 @@
                                         <color key="highlightedColor" name="black54"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sv4-33-u03" customClass="RSDRoundedButton" customModule="ResearchUI">
-                                        <rect key="frame" x="24" y="158.5" width="272" height="52"/>
+                                        <rect key="frame" x="24" y="158.5" width="272" height="34"/>
                                         <color key="backgroundColor" name="systemOrangeColor" catalog="System" colorSpace="catalog"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                         <state key="normal" title="Next">
@@ -386,7 +385,7 @@
                                                 </connections>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Step 1 of 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cCV-62-L3J">
-                                                <rect key="frame" x="122.5" y="28" width="76" height="17"/>
+                                                <rect key="frame" x="122" y="28" width="76" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" name="white"/>
                                                 <nil key="highlightedColor"/>
@@ -424,7 +423,7 @@
                                 <rect key="frame" x="0.0" y="77" width="320" height="160"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3:00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nll-PU-zj7">
-                                        <rect key="frame" x="135.5" y="67.5" width="49" height="26.5"/>
+                                        <rect key="frame" x="135.5" y="67" width="49" height="26.5"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="22"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
@@ -441,13 +440,13 @@
                                 <rect key="frame" x="20.5" y="237" width="279" height="279"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="1,730" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HYL-va-8cc">
-                                        <rect key="frame" x="41.5" y="70.5" width="195.5" height="98"/>
+                                        <rect key="frame" x="42" y="70.5" width="195.5" height="98"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="82"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="FEET" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZfB-yZ-HV9">
-                                        <rect key="frame" x="111.5" y="168" width="55" height="29"/>
+                                        <rect key="frame" x="112" y="168" width="55" height="29"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
@@ -545,7 +544,7 @@
                                                 </connections>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Step 1 of 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZC5-bR-tbv">
-                                                <rect key="frame" x="122.5" y="28" width="76" height="17"/>
+                                                <rect key="frame" x="122" y="28" width="76" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" name="white"/>
                                                 <nil key="highlightedColor"/>
@@ -584,7 +583,7 @@
                                 <rect key="frame" x="0.0" y="77" width="320" height="80"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="3:00" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="0H1-a5-wRw">
-                                        <rect key="frame" x="129" y="24" width="62" height="33.5"/>
+                                        <rect key="frame" x="129" y="23.5" width="62" height="33.5"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="28"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
@@ -669,7 +668,7 @@
                                                 </connections>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Step 1 of 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="7Ug-vB-zh5">
-                                                <rect key="frame" x="122.5" y="28" width="76" height="17"/>
+                                                <rect key="frame" x="122" y="28" width="76" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" name="gunmetal"/>
                                                 <nil key="highlightedColor"/>
@@ -722,44 +721,45 @@
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="s75-JE-o2a">
-                                <rect key="frame" x="20.5" y="237" width="279" height="279"/>
+                                <rect key="frame" x="51.5" y="237" width="217" height="217"/>
                                 <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </view>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l1n-cn-Sxa" customClass="RSDCountdownDial" customModule="ResearchUI">
-                                <rect key="frame" x="20.5" y="237" width="279" height="279"/>
+                                <rect key="frame" x="51.5" y="237" width="217" height="217"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <color key="tintColor" name="tealGreen"/>
                                 <constraints>
+                                    <constraint firstAttribute="height" priority="500" constant="250" id="1LO-nu-PYL"/>
                                     <constraint firstAttribute="width" secondItem="l1n-cn-Sxa" secondAttribute="height" multiplier="1:1" placeholder="YES" id="JDf-og-9Rv"/>
-                                    <constraint firstAttribute="width" constant="279" id="Xwg-p7-FA1"/>
                                 </constraints>
                             </view>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="heartRateIconCapturing" translatesAutoresizingMaskIntoConstraints="NO" id="JGX-wx-uQP">
-                                <rect key="frame" x="128" y="347.5" width="64" height="58"/>
+                                <rect key="frame" x="128" y="316.5" width="64" height="58"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                             </imageView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="I3P-qJ-Ohd">
-                                <rect key="frame" x="110" y="524" width="100" height="30"/>
+                                <rect key="frame" x="110" y="514" width="100" height="30"/>
                                 <state key="normal" title="skip heart rate"/>
                                 <connections>
                                     <action selector="skipForward" destination="8Jc-wF-FNR" eventType="touchUpInside" id="jDJ-o9-Xtj"/>
                                 </connections>
                             </button>
+                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="hdX-ET-Jiz">
+                                <rect key="frame" x="150" y="335.5" width="20" height="20"/>
+                            </activityIndicatorView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="--" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LFN-7W-56o">
-                                <rect key="frame" x="16" y="533" width="15.5" height="21"/>
-                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <rect key="frame" x="149.5" y="478" width="21.5" height="29"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <activityIndicatorView opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" hidesWhenStopped="YES" animating="YES" style="gray" translatesAutoresizingMaskIntoConstraints="NO" id="hdX-ET-Jiz">
-                                <rect key="frame" x="150" y="366" width="20" height="20"/>
-                            </activityIndicatorView>
                         </subviews>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <constraints>
                             <constraint firstItem="Sqy-a9-IDh" firstAttribute="trailing" secondItem="Cme-uq-pyz" secondAttribute="trailing" id="2DM-ZQ-rIB"/>
-                            <constraint firstItem="I3P-qJ-Ohd" firstAttribute="top" relation="greaterThanOrEqual" secondItem="s75-JE-o2a" secondAttribute="bottom" constant="8" id="3x6-lR-Xyz"/>
+                            <constraint firstItem="I3P-qJ-Ohd" firstAttribute="top" relation="greaterThanOrEqual" secondItem="s75-JE-o2a" secondAttribute="bottom" constant="60" id="3x6-lR-Xyz"/>
                             <constraint firstItem="Ybq-sF-bm4" firstAttribute="leading" secondItem="Sqy-a9-IDh" secondAttribute="leading" id="4AH-c4-3YS"/>
+                            <constraint firstItem="I3P-qJ-Ohd" firstAttribute="top" relation="greaterThanOrEqual" secondItem="LFN-7W-56o" secondAttribute="bottom" constant="4" id="7bq-dM-JUu"/>
                             <constraint firstItem="l1n-cn-Sxa" firstAttribute="top" secondItem="Cme-uq-pyz" secondAttribute="bottom" id="ANb-ix-Las"/>
                             <constraint firstItem="s75-JE-o2a" firstAttribute="centerY" secondItem="l1n-cn-Sxa" secondAttribute="centerY" id="BSk-bo-gxt"/>
                             <constraint firstItem="Ybq-sF-bm4" firstAttribute="top" secondItem="JaM-On-OUa" secondAttribute="topMargin" constant="12" id="BhD-bF-6zb"/>
@@ -770,11 +770,11 @@
                             <constraint firstItem="s75-JE-o2a" firstAttribute="height" secondItem="l1n-cn-Sxa" secondAttribute="height" id="Xax-FH-PfN"/>
                             <constraint firstAttribute="trailing" secondItem="Ybq-sF-bm4" secondAttribute="trailing" id="bBf-5n-C9E"/>
                             <constraint firstItem="JGX-wx-uQP" firstAttribute="centerY" secondItem="l1n-cn-Sxa" secondAttribute="centerY" id="fqm-bj-7uN"/>
-                            <constraint firstItem="Sqy-a9-IDh" firstAttribute="bottom" secondItem="LFN-7W-56o" secondAttribute="bottom" constant="14" id="iNv-P1-omQ"/>
+                            <constraint firstItem="LFN-7W-56o" firstAttribute="centerX" secondItem="JaM-On-OUa" secondAttribute="centerX" id="hTJ-24-bV1"/>
                             <constraint firstItem="I3P-qJ-Ohd" firstAttribute="centerX" secondItem="JaM-On-OUa" secondAttribute="centerX" id="jgM-HF-aK1"/>
                             <constraint firstItem="s75-JE-o2a" firstAttribute="centerX" secondItem="l1n-cn-Sxa" secondAttribute="centerX" id="lLP-Dh-LHZ"/>
+                            <constraint firstItem="LFN-7W-56o" firstAttribute="top" secondItem="s75-JE-o2a" secondAttribute="bottom" constant="24" id="lsI-f9-cz9"/>
                             <constraint firstItem="s75-JE-o2a" firstAttribute="width" secondItem="l1n-cn-Sxa" secondAttribute="width" id="n0D-59-Uaj"/>
-                            <constraint firstItem="LFN-7W-56o" firstAttribute="leading" secondItem="Sqy-a9-IDh" secondAttribute="leading" constant="16" id="qHE-kg-ug9"/>
                             <constraint firstItem="Cme-uq-pyz" firstAttribute="leading" secondItem="Sqy-a9-IDh" secondAttribute="leading" id="tKa-Bt-Sl8"/>
                             <constraint firstItem="Cme-uq-pyz" firstAttribute="top" secondItem="Ybq-sF-bm4" secondAttribute="bottom" id="x7B-cx-s4h"/>
                             <constraint firstItem="l1n-cn-Sxa" firstAttribute="centerX" secondItem="JaM-On-OUa" secondAttribute="centerX" id="yic-tI-Msn"/>
@@ -848,7 +848,7 @@
                                                 </connections>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Step 1 of 10" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HcR-Jr-8IM">
-                                                <rect key="frame" x="122.5" y="28" width="76" height="17"/>
+                                                <rect key="frame" x="122" y="28" width="76" height="17"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                                 <color key="textColor" name="gunmetal"/>
                                                 <nil key="highlightedColor"/>
@@ -892,7 +892,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="You’re all done!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="xkF-Cq-L5v">
-                                        <rect key="frame" x="84" y="69" width="153" height="26.5"/>
+                                        <rect key="frame" x="83.5" y="69" width="153" height="26.5"/>
                                         <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="22"/>
                                         <color key="textColor" name="textLightGray"/>
                                         <nil key="highlightedColor"/>
@@ -912,13 +912,13 @@
                                 <rect key="frame" x="30" y="293" width="260" height="130"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="180" textAlignment="natural" lineBreakMode="wordWrap" baselineAdjustment="alignBaselines" minimumFontSize="60" translatesAutoresizingMaskIntoConstraints="NO" id="zrU-lt-Md5">
-                                        <rect key="frame" x="0.0" y="-7" width="198" height="143.5"/>
+                                        <rect key="frame" x="0.0" y="-6.5" width="198" height="143.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="120"/>
                                         <color key="textColor" name="salmon"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="BPM" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gtz-sj-e2M">
-                                        <rect key="frame" x="210" y="50" width="50" height="29"/>
+                                        <rect key="frame" x="210" y="50.5" width="50" height="29"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="24"/>
                                         <color key="textColor" name="textDarkGray"/>
                                         <nil key="highlightedColor"/>
@@ -993,13 +993,13 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Great job!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="XQ2-tp-5pH">
-                                        <rect key="frame" x="109" y="65.5" width="101.5" height="26.5"/>
+                                        <rect key="frame" x="109.5" y="65.5" width="101.5" height="26.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="950" text="You just went" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Ow4-9h-rG1">
-                                        <rect key="frame" x="57.5" y="310" width="204.5" height="43"/>
+                                        <rect key="frame" x="58" y="310" width="204.5" height="43"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
@@ -1031,13 +1031,13 @@
                                         </constraints>
                                     </view>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="250" text="in 12 minutes" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SNV-1E-1kJ">
-                                        <rect key="frame" x="58.5" y="487" width="202.5" height="43"/>
+                                        <rect key="frame" x="59" y="487" width="202.5" height="43"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="TVD-qs-xxl" customClass="RSDRoundedButton" customModule="ResearchUI">
-                                        <rect key="frame" x="24" y="492" width="272" height="52"/>
+                                        <rect key="frame" x="24" y="509" width="272" height="35"/>
                                         <color key="backgroundColor" name="white"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                                         <color key="tintColor" name="darkPastelGreenTwo"/>
@@ -1113,19 +1113,19 @@
                                         </constraints>
                                     </imageView>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Great job!" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bex-yS-KXh">
-                                        <rect key="frame" x="109" y="65.5" width="101.5" height="26.5"/>
+                                        <rect key="frame" x="109.5" y="65.5" width="101.5" height="26.5"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="22"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="950" text="Your heart rate changed by" textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kIh-Jl-8y5">
-                                        <rect key="frame" x="24" y="280" width="272" height="86"/>
+                                        <rect key="frame" x="24" y="310" width="272" height="86"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="36"/>
                                         <color key="textColor" name="white"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l2w-IM-GMs">
-                                        <rect key="frame" x="83" y="384" width="155" height="98"/>
+                                        <rect key="frame" x="82.5" y="414" width="155" height="98"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="950" text="65" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aAS-tv-vtl">
                                                 <rect key="frame" x="0.0" y="0.0" width="97.5" height="98"/>
@@ -1151,7 +1151,7 @@
                                         </constraints>
                                     </view>
                                     <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JOO-0a-utf" customClass="RSDRoundedButton" customModule="ResearchUI">
-                                        <rect key="frame" x="24" y="492" width="272" height="52"/>
+                                        <rect key="frame" x="24" y="522" width="272" height="22"/>
                                         <color key="backgroundColor" name="white"/>
                                         <fontDescription key="fontDescription" type="boldSystem" pointSize="19"/>
                                         <color key="tintColor" name="darkPastelGreenTwo"/>
@@ -1218,19 +1218,19 @@
         <image name="heartRateIconCapturing" width="64" height="58"/>
         <image name="stairStepLarge1" width="375" height="501"/>
         <namedColor name="black54">
-            <color white="0.0" alpha="0.54000002150000004" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            <color white="0.0" alpha="0.54000002145767212" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </namedColor>
         <namedColor name="buttonTintBlue">
-            <color red="0.12941176469999999" green="0.58823529409999997" blue="0.95294117649999999" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.12941176470588237" green="0.58823529411764708" blue="0.95294117647058818" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="darkPastelGreen">
-            <color red="0.36862745099999999" green="0.67843137249999996" blue="0.3411764706" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.36862745098039218" green="0.67843137254901964" blue="0.3411764705882353" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="darkPastelGreenTwo">
             <color red="0.37647058823529411" green="0.69411764705882351" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="gunmetal">
-            <color red="0.25490196079999999" green="0.28235294119999998" blue="0.34901960780000002" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.25490196078431371" green="0.28235294117647058" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="perrywinkleTwo">
             <color red="0.61960784313725492" green="0.72941176470588232" blue="0.93725490196078431" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1242,7 +1242,7 @@
             <color red="0.0" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="tealGreen">
-            <color red="0.23921568630000001" green="0.74901960779999999" blue="0.63921568630000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23921568627450981" green="0.74901960784313726" blue="0.63921568627450975" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="textDarkGray">
             <color red="0.25490196078431371" green="0.28235294117647058" blue="0.34901960784313724" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateStepViewController.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateStepViewController.swift
@@ -86,6 +86,11 @@ public class CRFHeartRateStepViewController: RSDActiveStepViewController, CRFHea
         self.progressLabel?.isHidden = true
         self.skipButton?.isHidden = true
         self.heartImageView?.isHidden = true
+        
+        let localizationBundle = LocalizationBundle(Bundle(for: CRFHeartRateStepViewController.self))
+        Localization.insert(bundle: localizationBundle, at: 1)
+    
+        self.instructionLabel?.text = Localization.localizedString("HEARTRATE_CAPTURE_START_TEXT")
     }
     
     public override func viewDidAppear(_ animated: Bool) {
@@ -212,14 +217,14 @@ public class CRFHeartRateStepViewController: RSDActiveStepViewController, CRFHea
             self.loadingIndicator?.isHidden = true
             if isCoveringLens {
                 self._startCountdownIfNeeded()
+                self.instructionLabel?.text = Localization.localizedString("HEARTRATE_CAPTURE_CONTINUE_TEXT")
             } else {
                 // zero out the BPM to indicate to the user that they need to cover the flash
                 // and show the initial instruction.
                 self.progressLabel?.text = "--"
                 self._markTime = nil
-                if let instruction = self.activeStep?.spokenInstruction(at: 0) {
-                    self.instructionLabel?.text = instruction
-                }
+                self.vibrateDevice()
+                self.instructionLabel?.text = Localization.localizedString("HEARTRATE_CAPTURE_ERROR_TEXT")
             }
         }
     }

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateStepViewController.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateStepViewController.swift
@@ -264,15 +264,19 @@ public class CRFHeartRateStepViewController: RSDActiveStepViewController, CRFHea
     
     private func _updateBPMLabel(_ bpm: Int) {
         if self.collectionResult?.inputResults.count ?? 0 == 0 {
-            // Add the starting heart rate as a result for display to the user
+            // Add the starting heart rate
             var bpmResult = RSDAnswerResultObject(identifier: "\(self.step.identifier)_start", answerType: RSDAnswerResultType(baseType: .decimal))
             bpmResult.value = bpmRecorder?.bpm
             addResult(bpmResult)
-        } else if !_encouragementGiven, let markTime = _markTime, (ProcessInfo.processInfo.systemUptime - markTime) > 40,
-            let continueText = self.uiStep?.detail {
-            _encouragementGiven = true
-            self.speakInstruction(continueText, at: 40, completion: nil)
         }
-        self.progressLabel?.text = numberFormatter.string(from: NSNumber(value: bpm))
+        // TODO: syoung 09/28/2018 Save for now in case UX changes again to include spoken "encouragement" text.
+        //    else if !_encouragementGiven, let markTime = _markTime, (ProcessInfo.processInfo.systemUptime - markTime) > 40,
+        //        let continueText = self.uiStep?.detail {
+        //        _encouragementGiven = true
+        //        self.speakInstruction(continueText, at: 40, completion: nil)
+        //    }
+        if let bpmString = numberFormatter.string(from: NSNumber(value: bpm)) {
+            self.progressLabel?.text = Localization.localizedStringWithFormatKey("HEARTRATE_CAPTURE_%@_BPM", bpmString)
+        }
     }
 }

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CardiorespiratoryFitness.strings
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CardiorespiratoryFitness.strings
@@ -35,3 +35,4 @@
 "HEARTRATE_CAPTURE_START_TEXT"    = "Gently cover both the camera and flash with your finger";
 "HEARTRATE_CAPTURE_CONTINUE_TEXT" = "Please keep your hands and body still";
 "HEARTRATE_CAPTURE_ERROR_TEXT"    = "Please place finger back on the camera and flash";
+"HEARTRATE_CAPTURE_%@_BPM"        = "%@ BPM";

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CardiorespiratoryFitness.strings
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CardiorespiratoryFitness.strings
@@ -1,0 +1,37 @@
+/* 
+  Research.strings
+  Research
+
+    Copyright © 2017-2018 Sage Bionetworks. All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without modification,
+    are permitted provided that the following conditions are met:
+
+    1.  Redistributions of source code must retain the above copyright notice, this
+    list of conditions and the following disclaimer.
+
+    2.  Redistributions in binary form must reproduce the above copyright notice,
+    this list of conditions and the following disclaimer in the documentation and/or
+    other materials provided with the distribution.
+
+    3.  Neither the name of the copyright holder(s) nor the names of any contributors
+    may be used to endorse or promote products derived from this software without
+    specific prior written permission. No license is granted to the trademarks of
+    the copyright holders even if such marks are included in this software.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+    ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+"HEARTRATE_CAPTURE_START_TEXT"    = "Gently cover both the camera and flash with your finger";
+"HEARTRATE_CAPTURE_CONTINUE_TEXT" = "Please keep your hands and body still";
+"HEARTRATE_CAPTURE_ERROR_TEXT"    = "Please place finger back on the camera and flash";

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/HeartrateStep.json
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/HeartrateStep.json
@@ -20,19 +20,10 @@
                            {
                            "identifier"   : "heartRate",
                            "type"         : "heartRate",
-                           "text"         : "Gently cover both the camera and flash with your finger.",
-                           "detail"       : "Doing a great job of keeping your finger on the camera!",
                            "shouldHideActions": ["goBackward", "goForward"],
                            "duration": 60,
-                           "commands": ["playSound", "continueOnFinish", "shouldDisableIdleTimer"],
-                           "requiresBackgroundAudio": true,
-                           "spokenInstructions": {
-                                "0" : "Gently cover both the camera and flash with your finger.",
-                                "5": "Please keep still",
-                                "halfway": "You’re half way there!",
-                                "45": "Just 15 seconds left",
-                                "end": "You’re all done!"
-                           }
+                           "commands": ["vibrate", "continueOnFinish", "shouldDisableIdleTimer"],
+                           "requiresBackgroundAudio": true
                            },
                            {
                            "identifier"   : "feedback",


### PR DESCRIPTION
Use a workspace to add the validation app to the same project as the CRF module.

This adds a git submodule dependency on BridgeApp *without* directly referencing it in CRF. The CRF project (including a test app) is self-encompassing but I can make edits to it (and to Research) without having to maintain two orthogonal references to the same framework. 

Note: Using this method, the `CardiorespiratoryFitnesss` project and `BridgeApp` project will both build independently, but the validation app requires the shared workspace.