### PR TITLE
Fix build

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -111,8 +111,6 @@ platform :ios do
     project = options[:project]
     scheme = options[:scheme]
     export_method = options[:export_method]
-    keychains
-    certificates
     archive(project: "#{project}",scheme: "#{scheme}",export_method: "#{export_method}")
   end
 
@@ -122,8 +120,6 @@ platform :ios do
     scheme = options[:scheme]
     export_method = options[:export_method]
     ensure_git_status_clean
-    keychains
-    certificates
     version_number = get_version_number(xcodeproj: "#{project}", target: "#{scheme}")
     next_build_number = increment_build_number(xcodeproj: "#{project}")
     archive(project: "#{project}", scheme: "#{scheme}", export_method: "#{export_method}")

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -6,11 +6,15 @@ if [[ "$TRAVIS_PULL_REQUEST" != "false" ]]; then     # on pull requests
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag commits to master branch
     echo "Build on merge to master"
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test project:"CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj"  scheme:"CRFTestApp"
+    bundle exec keychains
+    bundle exec certificates
     bundle exec fastlane ci_archive scheme:"CRFTestApp" export_method:"app-store" project:"CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj"
     bundle exec fastlane ci_archive scheme:"CRFHeartRate" export_method:"app-store" project:"CRFHeartRate/CRFHeartRate.xcodeproj"
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag commits to stable branches
     echo "Build on stable branch"
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane test project:"CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj"  scheme:"CRFTestApp"
+    bundle exec keychains
+    bundle exec certificates
     bundle exec fastlane beta scheme:"CRFTestApp" export_method:"app-store" project:"CardiorespiratoryFitness/CardiorespiratoryFitness.xcodeproj"
     bundle exec fastlane beta scheme:"CRFHeartRate" export_method:"app-store" project:"CRFHeartRate/CRFHeartRate.xcodeproj"
 fi


### PR DESCRIPTION
Build failed because it attempted to create a keychain twice.  Run
create keychain and get certificates only once for both CRFTestApp
and CRFHeartRate target builds.