### PR TITLE
Tweeks of the heart rate algorithm to accomidate both iPhone Plus and X

### DIFF
--- a/CRFHeartRate/CRFHeartRate/ParticipantIDStepViewController.swift
+++ b/CRFHeartRate/CRFHeartRate/ParticipantIDStepViewController.swift
@@ -64,7 +64,7 @@ class ParticipantIDStepViewController: RSDTableStepViewController {
             else {
                 fatalError("Attempting to go forward without an answer result.")
         }
-        guard !UserDefaults.standard.bool(forKey: participantID)
+        guard participantID == "00" || !UserDefaults.standard.bool(forKey: participantID)
             else {
                 handlePreviouslyUsed(participantID)
                 return

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateVideoProcessor.h
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/CRFHeartRateVideoProcessor.h
@@ -37,11 +37,12 @@
 NS_ASSUME_NONNULL_BEGIN
 
 struct CRFPixelSample {
-    double uptime;
+    double presentationTimestamp;
     double red;
     double green;
     double blue;
-    double redLevel;
+    double redSD;
+    bool isCoveringLens;
 };
 
 @class CRFHeartRateVideoProcessor;


### PR DESCRIPTION
The iPhone X has a yellow tone of color whereas the iPhone Plus is red. The result is that depending upon the device, the calculated heart rate needs to look at either the red or green channel. Additionally, moved to checking the standard deviation on the red channel instead of just a count of red dominant b/c the yellow isn’t recognized as covered. This means that the lens is considered covered by anything that is covering it, but that’s okay for purposes of triggering start.

Note 1: I had been avoiding using a standard deviation calculation b/c it is more expensive to process. Will need to test performance on min hardware.

Note 2: Currently, I am only calculating the heart rate every 5 seconds, but I check both red and green channels b/c the confidence is significantly higher on one channel vs. the other depending upon the device. Might want to consider changing this to use a lookup table of known devices to determine which channel to use. Also, may what to do some performance testing on min hardware.