### PR TITLE
update apple connect service account

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,5 +1,5 @@
 app_identifier "org.sagebase.CRFHeartRate" # The bundle identifier of your app
-apple_id "apple.developer@sagebase.org" # Your Apple email address
+apple_id "appleservicer@sagebase.org" # Your Apple email address
 
 team_id "KA9Z8R6M6K"  # Developer Portal Team ID
 

--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -7,4 +7,4 @@
 # Feel free to remove the following line if you use fastlane (which you should)
 
 app_identifier "org.sagebase.CRFHeartRate" # The bundle identifier of your app
-username "apple.developer@sagebase.org" # your Apple ID user
+username "appleservicer@sagebase.org" # your Apple ID user

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -8,7 +8,7 @@ app_identifier [
   "org.sagebase.CRFTestApp",
   "org.sagebase.CRFHeartRate"]
 
-username "apple.developer@sagebase.org" # Your Apple Developer Portal username
+username "appleservicer@sagebase.org" # Your Apple Developer Portal username
 
 readonly true
 # For all available options run `fastlane match --help`


### PR DESCRIPTION
The apple.developer@sagebase.com account is setup with MFA so it
can no longer be used as a service account. Update with new
service account for deploying to apple itunes.