### PR TITLE
Fix bug with sample rate rounding

### DIFF
--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/Swift/iOS/CRFHeartRateSampleProcessor.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/Swift/iOS/CRFHeartRateSampleProcessor.swift
@@ -247,7 +247,7 @@ internal class CRFHeartRateSampleProcessor {
     // in the filters before calculating.
     
     func calculateHeartRate(_ input: [Double], samplingRate: Double) -> (heartRate: Double, confidence: Double) {
-        let window = Int(ceil(CRFHeartRateWindowSeconds * samplingRate))
+        let window = Int(round(CRFHeartRateWindowSeconds * samplingRate))
         guard let filtered = getFilteredSignal(input, samplingRate: Int(round(samplingRate))),
             filtered.count >= window
             else {


### PR DESCRIPTION
@syoung-smallwisdom I did some investigating to determine the source of the original issue on my iPodTouch.  It turns out there is a rounding error with regards to certain sampling frame rates.  My iPodTouch has a calculated sample rate of 60.14224671275254 and when the window is calculated, it requires 602 samples to calculate HR, but the filtered signal function only ends up producing 601 samples, even when there is more than enough data.   This causes the calculateHeartRate algorithm to always return (0, 0) which was why I was always seeing the "We're having trouble seeing your heart rate" screen. 