### PR TITLE
Gender Hot-fix

### DIFF
--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFTaskInfo.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFTaskInfo.swift
@@ -42,7 +42,7 @@ public enum CRFTaskIdentifier : String, Codable, CaseIterable {
     /// Measure your heart rate while resting.
     case resting = "Resting Heart Rate"
     
-    /// Heart snapshot does the stair step VO2 max test with sex and birthYear questions.
+    /// Heart snapshot does the stair step VO2 max test with gender and birthYear questions.
     case heartSnapshot = "HeartSnapshot"
     
     func task(with factory: CRFFactory) -> RSDTaskObject {

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Demographics_questions.html
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Demographics_questions.html
@@ -16,7 +16,7 @@
 <div class="container">
     <div class="content">
         <p>
-        We use your sex and age in the equation to calculate your Recovery HR Score. Knowing your sex makes the calculation more precise, but we can still estimate your Recovery HR Score if you answer ‘Other’ or if you would prefer not to answer this question.
+        We use your gender and age in the equation to calculate your Recovery HR Score. Knowing your gender makes the calculation more precise, but we can still estimate your Recovery HR Score if you answer ‘Other’ or if you would prefer not to answer this question.
         </p>
     </div>
 </div>

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Heart_Snapshot.json
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/iOS/Heart_Snapshot.json
@@ -63,7 +63,7 @@
         "identifier": "demographics",
         "type": "instruction",
         "title": "Recovery HR Questions",
-        "text": "To calculate your Recovery HR score, we first need to know a few things about you like your sex and age.",
+        "text": "To calculate your Recovery HR score, we first need to know a few things about you like your gender and age.",
         "image": {
             "type": "fetchable",
             "imageName": "RecoveryQuestions",
@@ -79,7 +79,7 @@
     {
         "identifier": "sex",
         "type": "demographics",
-        "title": "What is your sex?",
+        "title": "What is your gender?",
         "inputFields": [{
             "uiHint": "list",
             "type": "singleChoice.string",
@@ -92,7 +92,7 @@
                 "value": "female"
             },
             {
-                "text": "Other, or prefer not to answer",
+                "text": "Does not apply or prefer not to answer",
                 "value": "other"
             }
             ]
@@ -108,7 +108,7 @@
             },
             "learnMore": {
                 "type": "webView",
-                "title": "Why are we asking about your sex?",
+                "title": "Why are we asking about your gender?",
                 "usesBackButton": true,
                 "url": "Demographics_questions.html",
                 "buttonTitle": "Why are we asking this?"


### PR DESCRIPTION
@syoung-smallwisdom @Erin-Mounts Switched all user facing copy including “sex” to “gender”.  Switching the underlying data model to use gender as the identifier seemed out of scope, but at least for the first public revealing of the CRF module, it will have "gender" as the copy.