### PR TITLE
STEP-86 tips for measuring bug

### DIFF
--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFHeartRateStep.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFHeartRateStep.swift
@@ -107,12 +107,11 @@ open class CRFHeartRateStep : RSDActiveUIStepObject, RSDRestartableRecorderConfi
             learnMore.title = Localization.localizedString("HEARTRATE_LEARN_TIPS_BUTTON")
             learnMore.factoryBundle = Bundle(for: CRFHeartRateStep.self)
             learnMore.usesBackButton = true
-            if self.actions != nil {
-                self.actions![.navigation(.learnMore)] = learnMore
+            
+            if self.actions == nil {
+                self.actions = [:]
             }
-            else {
-                self.actions = [.navigation(.learnMore): learnMore]
-            }
+            self.actions![.navigation(.learnMore)] = learnMore
         }
     }
     

--- a/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFHeartRateStep.swift
+++ b/CardiorespiratoryFitness/CardiorespiratoryFitness/Model/CRFHeartRateStep.swift
@@ -103,17 +103,15 @@ open class CRFHeartRateStep : RSDActiveUIStepObject, RSDRestartableRecorderConfi
             }
             self.requiresBackgroundAudio = true
             
-            if self.isResting {
-                var learnMore = RSDWebViewUIActionObject(url: "Tips_for_measuring.html", buttonTitle: Localization.localizedString("HEARTRATE_LEARN_TIPS_TITLE"))
-                learnMore.title = Localization.localizedString("HEARTRATE_LEARN_TIPS_BUTTON")
-                learnMore.factoryBundle = Bundle(for: CRFHeartRateStep.self)
-                learnMore.usesBackButton = true
-                if self.actions != nil {
-                    self.actions![.navigation(.learnMore)] = learnMore
-                }
-                else {
-                    self.actions = [.navigation(.learnMore): learnMore]
-                }
+            var learnMore = RSDWebViewUIActionObject(url: "Tips_for_measuring.html", buttonTitle: Localization.localizedString("HEARTRATE_LEARN_TIPS_TITLE"))
+            learnMore.title = Localization.localizedString("HEARTRATE_LEARN_TIPS_BUTTON")
+            learnMore.factoryBundle = Bundle(for: CRFHeartRateStep.self)
+            learnMore.usesBackButton = true
+            if self.actions != nil {
+                self.actions![.navigation(.learnMore)] = learnMore
+            }
+            else {
+                self.actions = [.navigation(.learnMore): learnMore]
             }
         }
     }


### PR DESCRIPTION
Learn more bug fix from https://sagebionetworks.jira.com/browse/STEP-86.  

When "isResting" is false, the learn more action is not added; however, the action button "tips for measuring" is still shown when a user fails their heart rate and can be clicked.  As a result the user was seeing the screenshot in the Jira issue.

Video of it working as I think was intended in the Jira issue as well.

@syoung-smallwisdom @Erin-Mounts for review and merge

